### PR TITLE
Add optional memorysaver/skills supplement; modernize onboard install (1.3.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
     "email": "mho@looplia.run"
   },
   "metadata": {
-    "version": "1.2.0",
+    "version": "1.3.0",
     "description": "Skills for product planning, project scaffolding, and agentic development workflows."
   },
   "plugins": [

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,26 @@ bug fixes → **patch**; removing or breaking a skill contract → **major**.
 
 _Nothing yet._
 
+## [1.3.0] - 2026-06-04
+
+Adds an optional supplement and modernizes onboarding to the `npx skills` installer.
+
+### Added
+
+- Optional **supplement** pointer to [`memorysaver/skills`](https://github.com/memorysaver/skills)
+  in the README and `/onboard`: `project-behavior` (scaffold an `AGENTS.md` behavior pack),
+  `project-memory` (git-committable memory system), and `memory-forge` (distill lessons into
+  skills). The `/onboard` and README "Agent prompt" flows now **always ask** whether the user
+  wants the `AGENTS.md` behavior config and the memory system before installing either.
+
+### Changed
+
+- `/onboard` (aep-onboard) Phase 1 install modernized from the legacy
+  `/plugin marketplace add` and `/plugin install` commands to project-level
+  `npx skills add memorysaver/agentic-engineering-patterns@<latest-tag>` (pin to the latest
+  release, commit the installed files), matching the README install guide.
+- `.claude-plugin/marketplace.json` version `1.2.0` → `1.3.0`.
+
 ## [1.2.0] - 2026-06-04
 
 Host-agnostic executor: the feature lifecycle now runs under Claude Code **or**
@@ -117,7 +137,8 @@ First stable baseline after the Jujutsu → git migration. Decision record:
 
 - Jujutsu (one-shot migration, no dual-mode period) and the `/jj-ref` skill.
 
-[Unreleased]: https://github.com/memorysaver/agentic-engineering-patterns/compare/v1.2.0...HEAD
+[Unreleased]: https://github.com/memorysaver/agentic-engineering-patterns/compare/v1.3.0...HEAD
+[1.3.0]: https://github.com/memorysaver/agentic-engineering-patterns/compare/v1.2.0...v1.3.0
 [1.2.0]: https://github.com/memorysaver/agentic-engineering-patterns/compare/v1.1.0...v1.2.0
 [1.1.0]: https://github.com/memorysaver/agentic-engineering-patterns/compare/v1.0.0...v1.1.0
 [1.0.0]: https://github.com/memorysaver/agentic-engineering-patterns/releases/tag/v1.0.0

--- a/README.md
+++ b/README.md
@@ -61,6 +61,16 @@ Install the Agentic Engineering Patterns (AEP) skills into this project, pinned 
      `npx skills add memorysaver/agentic-engineering-patterns@<newtag>` once per agent.
 
 5. Verify with `npx skills list`. Restore from the lockfile later with `npx skills experimental_install`.
+
+6. Then ALWAYS ASK the user which optional add-ons they want — both come from
+   memorysaver/skills (newest tag at https://github.com/memorysaver/skills/releases/latest):
+     a. "Set up behavioral guidelines (a coding-discipline preamble) in AGENTS.md?"
+        If yes → install `project-behavior`, then run it to scaffold/extend AGENTS.md.
+     b. "Set up a project memory system (committed lessons + recall)?"
+        If yes → install `project-memory` (and `memory-forge`), then run project-memory to
+        bootstrap project-memory/.
+   Install each chosen skill once per agent, then commit the installed files (the commit is the pin):
+     npx skills add memorysaver/skills@<latest-tag> -a claude-code --skill project-behavior -y
 ```
 
 ### Quick start
@@ -104,6 +114,27 @@ still equals the locked content. To truly freeze a release, **commit the install
 (under `.claude/skills/` and/or `.agents/skills/`) together with `skills-lock.json`. The committed
 bytes become the pin: teammates, CI, and Codex need no install step, and nothing drifts when
 upstream moves on. Upgrade deliberately by re-running `add@<newtag>` in its own PR.
+
+### Optional supplement: behavior + memory
+
+Two project-level capabilities AEP doesn't ship itself live in a separate repo,
+[`memorysaver/skills`](https://github.com/memorysaver/skills). Install them as an
+**optional supplement** — once per agent (`-a claude-code`, then `-a codex`):
+
+```bash
+npx skills add memorysaver/skills@<latest-tag> -a claude-code \
+  --skill project-behavior --skill project-memory --skill memory-forge
+```
+
+- **`project-behavior`** — scaffolds/extends your `AGENTS.md` with a behavioral preamble
+  (a Karpathy coding-discipline pack by default); run it after installing.
+- **`project-memory`** — bootstraps a git-committable `project-memory/` system for session
+  lessons, retrospectives, and qmd-backed recall; run it to set the system up.
+- **`memory-forge`** — later distills aged `project-memory/` lessons into reusable skills.
+
+These aren't part of AEP's versioned release — pin them the same way you pin AEP: install the
+latest [`memorysaver/skills`](https://github.com/memorysaver/skills/releases/latest) release
+tag, then **commit the installed files** to freeze it.
 
 ### Keep your formatter off the skills
 

--- a/skills/project-setup/onboard/SKILL.md
+++ b/skills/project-setup/onboard/SKILL.md
@@ -31,27 +31,29 @@ Before installing tools, get the mental model. AEP is not a "command runner" —
 
 ## Phase 1 — Install the Plugin
 
-Add the marketplace and install both plugin groups:
+Install the AEP skills with the [`skills`](https://github.com/vercel-labs/skills) CLI at **project level**, once per agent your project uses. Pin to the latest release and commit the installed files so the version is frozen for your team:
 
 ```bash
-# Add the marketplace
-/plugin marketplace add memorysaver/agentic-engineering-patterns
-
-# Install plugin groups
-/plugin install product-context@agentic-engineering-patterns
-/plugin install project-setup@agentic-engineering-patterns
-/plugin install agentic-development-workflow@agentic-engineering-patterns
+# Claude Code (repeat with `-a codex` for Codex). Newest tag:
+# https://github.com/memorysaver/agentic-engineering-patterns/releases/latest
+npx skills add memorysaver/agentic-engineering-patterns@<latest-tag> -a claude-code --skill '*' -y
 ```
 
-### Plugin Groups
+This installs every AEP skill (the `aep-*` names) plus a `skills-lock.json` manifest — **commit both**. For the full pinning + formatter guidance, see [Installing Skills](../../../README.md#installing-skills).
 
-| Group                            | Skills                               | Purpose                                                                      |
-| -------------------------------- | ------------------------------------ | ---------------------------------------------------------------------------- |
-| **product-context**              | envision, map, dispatch, reflect     | Product-level planning and iteration                                         |
-| **project-setup**                | onboard, scaffold                    | Scaffold projects, configure spec-driven development, environment onboarding |
-| **agentic-development-workflow** | design, launch, build, wrap, git-ref | Full-lifecycle feature development with git worktrees                        |
+### Optional add-ons — always ask the user
 
-> **Note:** This installs the agentic-engineering-patterns plugin itself. Recommended third-party plugins are configured at the project level in Phase 4 via `.claude/settings.json`; browser automation is added only after its local smoke test passes.
+AEP pairs with two project-level skills from [`memorysaver/skills`](https://github.com/memorysaver/skills). **Ask the user whether they want each**, and install only what they choose (newest tag at <https://github.com/memorysaver/skills/releases/latest>, once per agent):
+
+- **Behavioral guidelines in `AGENTS.md`?** → install `project-behavior`, then run it to scaffold/extend `AGENTS.md`.
+- **A project memory system (committed lessons + recall)?** → install `project-memory` (and `memory-forge`), then run `project-memory` to bootstrap `project-memory/`.
+
+```bash
+npx skills add memorysaver/skills@<latest-tag> -a claude-code \
+  --skill project-behavior --skill project-memory --skill memory-forge -y
+```
+
+> **Note:** This installs the AEP skills themselves. Recommended third-party Claude Code plugins are configured at the project level in Phase 4 via `.claude/settings.json`; browser automation is added only after its local smoke test passes.
 
 ---
 


### PR DESCRIPTION
Points AEP at an **optional supplement** from [`memorysaver/skills`](https://github.com/memorysaver/skills) and modernizes onboarding to the `npx skills` installer. Cuts **v1.3.0** (minor).

## What changed
- **README** — new `### Optional supplement: behavior + memory` subsection, and a new Agent-prompt step that **always asks** the user whether they want:
  - **AGENTS.md behavior config** → `project-behavior`
  - **a project memory system** → `project-memory` (+ `memory-forge`)
  Both pin to the latest `memorysaver/skills` release tag and freeze by committing the installed files.
- **onboard (aep-onboard) Phase 1** — replaced the legacy `/plugin marketplace add` + `/plugin install` with project-level `npx skills add ...@<latest-tag>`, and added the same ask-first supplement step.
- **Version** — `marketplace.json` 1.2.0 → 1.3.0; `CHANGELOG.md` `[1.3.0]`.

## Notes
- The supplement skills are **not** part of AEP's versioned release — they're an external pointer; the bump covers the onboard modernization + docs.
- Paired with a separate PR on `memorysaver/skills` that cuts its first release (v0.1.0) so the `@<latest-tag>` pins resolve.

## On merge
Tag `v1.3.0` + cut the GitHub release (per the CHANGELOG maintenance convention).

🤖 Generated with [Claude Code](https://claude.com/claude-code)