### PR TITLE
fix(executor): correct cmux review-surface attach in /launch (v1.3.2)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
     "email": "mho@looplia.run"
   },
   "metadata": {
-    "version": "1.3.1",
+    "version": "1.3.2",
     "description": "Skills for product planning, project scaffolding, and agentic development workflows."
   },
   "plugins": [

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,28 @@ bug fixes → **patch**; removing or breaking a skill contract → **major**.
 
 _Nothing yet._
 
+## [1.3.2] - 2026-06-05
+
+Fixes how `/launch` and the executor attach a cmux review surface (reported and
+verified from a downstream session).
+
+### Fixed
+
+- **cmux detection no longer requires `$CMUX_SOCKET`.** A host where the `cmux` CLI
+  is reachable but `$CMUX_SOCKET` is unset (Claude Code inside a cmux-managed tmux
+  session) wrongly fell back to headless B2. Detection now keys on "cmux CLI
+  reachable **and** a target pane resolves" (`cmux tree` `◀ here` / `$CMUX_PANE_ID`).
+- **The review tab opens as a sibling of the orchestrator's own tab.** The old bare
+  `cmux new-surface` defaulted to an unset `$CMUX_WORKSPACE_ID`; `/launch` now
+  resolves the orchestrator's pane from `cmux tree` and opens the tab with
+  `new-surface --workspace <ws> --pane <pane> --focus true`. `cmux new-workspace`
+  (a separate top-level workspace) is kept out of the launch path.
+- **Bootstrap is sent before the cmux surface attaches.** An attached cmux surface
+  focuses the tmux composer and blocks external `send-keys`, so the bootstrap
+  couldn't land. Reordered to: spawn tmux → wait ready → send bootstrap via
+  `tmux send-keys` → then attach the cmux tab.
+- `.claude-plugin/marketplace.json` version `1.3.1` → `1.3.2`.
+
 ## [1.3.1] - 2026-06-05
 
 Onboarding refinements: OpenSpec is now a required install step, and the optional
@@ -161,7 +183,8 @@ First stable baseline after the Jujutsu → git migration. Decision record:
 
 - Jujutsu (one-shot migration, no dual-mode period) and the `/jj-ref` skill.
 
-[Unreleased]: https://github.com/memorysaver/agentic-engineering-patterns/compare/v1.3.1...HEAD
+[Unreleased]: https://github.com/memorysaver/agentic-engineering-patterns/compare/v1.3.2...HEAD
+[1.3.2]: https://github.com/memorysaver/agentic-engineering-patterns/compare/v1.3.1...v1.3.2
 [1.3.1]: https://github.com/memorysaver/agentic-engineering-patterns/compare/v1.3.0...v1.3.1
 [1.3.0]: https://github.com/memorysaver/agentic-engineering-patterns/compare/v1.2.0...v1.3.0
 [1.2.0]: https://github.com/memorysaver/agentic-engineering-patterns/compare/v1.1.0...v1.2.0

--- a/skills/agentic-development-workflow/launch/SKILL.md
+++ b/skills/agentic-development-workflow/launch/SKILL.md
@@ -112,15 +112,9 @@ git worktree add -b feat/<name> .feature-workspaces/<name> main
 [ -z "$EXECUTOR" ] && { echo "run detect() first — \$EXECUTOR unset (would launch a bare shell)"; exit 1; }
 tmux new-session -d -s <name> -c .feature-workspaces/<name> "$EXECUTOR"
 
-# cmux is OPTIONAL — only create a tab if we are actually INSIDE a cmux surface.
-# (Merely having cmux installed does not let us spawn a sibling tab → would fail.)
-if [ -n "$CMUX_SOCKET" ]; then
-  GEN_SURFACE=$(cmux new-surface --type terminal | grep -o 'surface:[0-9]*')   # B1
-  cmux send --surface "$GEN_SURFACE" "tmux attach -t <name>\n"
-  cmux rename-tab --surface "$GEN_SURFACE" "<name>"
-else
-  echo "No cmux surface — workspace runs in tmux session '<name>'. Watch it: tmux attach -t <name>"  # B2
-fi
+# cmux is OPTIONAL and is attached LATER — after the bootstrap is sent. Attaching a
+# cmux surface focuses the tmux composer and blocks external send-keys, so the
+# prompt must land first. See "Attach the cmux Review Tab" after Send Bootstrap.
 ```
 
 > **No tmux at all (Desktop → B3) / dynamic workflow (B4):** do **not** use the
@@ -180,15 +174,43 @@ PROMPT="/build execute implementation for openspec change <change-name>. Read th
 <relevant lessons summary, if any — omit this section if no lessons exist>
 "
 
-if [ -n "$GEN_SURFACE" ]; then
-  cmux send --surface "$GEN_SURFACE" "$PROMPT"        # B1 (cmux sends the whole string)
-else
-  # B2: -l sends the literal multi-line text; a separate Enter submits it ONCE.
-  # (A bare `send-keys "$PROMPT" Enter` would let embedded newlines submit it line-by-line.)
-  tmux send-keys -t <name>:0.0 -l -- "$PROMPT"
-  tmux send-keys -t <name>:0.0 Enter
-fi
+# B1/B2: send the bootstrap over tmux BEFORE any cmux tab attaches (a cmux surface
+# focuses the composer and blocks external send-keys, so it must land first). -l
+# sends the literal multi-line text; a separate Enter submits it ONCE. (A bare
+# `send-keys "$PROMPT" Enter` would let embedded newlines submit it line-by-line.)
+# A very large paste can collapse to a "paste again to expand" prompt — if so, a
+# second Enter submits it.
+tmux send-keys -t <name>:0.0 -l -- "$PROMPT"
+tmux send-keys -t <name>:0.0 Enter
 # B3/B4: $PROMPT was passed as the agent's initial prompt at spawn() — nothing to send here.
+```
+
+---
+
+## Attach the cmux Review Tab (B1)
+
+**Only after the bootstrap has been sent.** On a cmux host (detection set
+`PRESENT=cmux`), open a review tab as a **sibling in the pane that holds the
+orchestrator's own tab** — not `cmux new-workspace` (which makes a separate
+top-level workspace) and not a bare `cmux new-surface` (which defaults to an unset
+`$CMUX_WORKSPACE_ID`). `cmux tree` marks the orchestrator's tab `◀ here`; fall back
+to the surface env vars when inside one. Skip this entire step under B2/B3/B4.
+
+```bash
+# $CMUX is the cmux CLI path resolved in detect().
+read -r WS PANE < <("$CMUX" tree 2>/dev/null | awk '
+  /workspace workspace:/ {for (i=1;i<=NF;i++) if ($i ~ /^workspace:/) ws=$i}
+  /pane pane:/           {for (i=1;i<=NF;i++) if ($i ~ /^pane:/)      pane=$i}
+  /◀ here/               {print ws, pane; exit}')
+: "${WS:=$CMUX_WORKSPACE_ID}" "${PANE:=$CMUX_PANE_ID}"
+if [ -n "$PANE" ]; then                                  # genuine B1 — a target pane exists
+  SREF=$("$CMUX" new-surface --type terminal --workspace "$WS" --pane "$PANE" --focus true \
+         | grep -oE 'surface:[0-9]+' | head -1)
+  "$CMUX" send --surface "$SREF" "tmux attach -t <name>"$'\n'   # trailing newline submits
+  "$CMUX" rename-tab --surface "$SREF" "<name>"
+else                                                     # reachable but no pane → headless B2
+  echo "cmux reachable but no target pane — workspace runs headless: tmux attach -t <name>"
+fi
 ```
 
 ---

--- a/skills/patterns/executor/SKILL.md
+++ b/skills/patterns/executor/SKILL.md
@@ -111,8 +111,8 @@ Invoked directly, this skill reports what would happen:
 
 1. Run the detection recipe from `references/backends.md`.
 2. Print: host (claude/codex/generic), executor binary, tmux present?, cmux
-   present? (env vs installed), workflow-capable?, and the **selected backend**
-   with the reason.
+   present? (CLI reachable + a `cmux tree` target pane resolves), workflow-capable?,
+   and the **selected backend** with the reason.
 3. If the user asked "why not workflow", explain the opt-in + host gate.
 
 This does not spawn anything — it is a dry-run of `detect()`.
@@ -129,9 +129,9 @@ This does not spawn anything — it is a dry-run of `detect()`.
 
 **Why backend selection is automatic (no flags/pins):**
 
-- Detection is reliable from env markers (`$CLAUDECODE`, `$CODEX_*`,
-  `$CMUX_SOCKET`, `$TMUX`) plus `command -v`. An override mechanism adds surface
-  area for little gain.
+- Detection is reliable from env markers (`$CLAUDECODE`, `$CODEX_*`, `$TMUX`) plus
+  `command -v` and a `cmux tree` pane probe (cmux is usable without `$CMUX_SOCKET`).
+  An override mechanism adds surface area for little gain.
 - The single manual lever is the dynamic-workflow opt-in, expressed in natural
   language ("…with workflow"), consistent with the Workflow tool's own opt-in.
 

--- a/skills/patterns/executor/references/backends.md
+++ b/skills/patterns/executor/references/backends.md
@@ -48,9 +48,14 @@ fi
 [ -z "$EXECUTOR" ] && { echo "executor unresolved — set \$AEP_EXECUTOR or run under Claude Code / Codex"; }
 
 # --- PRESENTATION: how a human watches a running session ---
-# Use cmux only when we are actually INSIDE a cmux surface ($CMUX_SOCKET) — being
-# merely installed (command -v) does NOT let us spawn a sibling tab.
-if [ -n "$CMUX_SOCKET" ]; then
+# cmux can host a review tab whenever its CLI is reachable AND we can resolve a
+# target pane — it does NOT require $CMUX_SOCKET. The cmux CLI drives cmux over its
+# Unix socket even when $CMUX_SOCKET is unset (e.g. Claude Code inside a
+# cmux-managed tmux session does not inherit it). Resolve the binary robustly, then
+# confirm a target pane exists: `cmux tree` marks the orchestrator's own pane
+# "◀ here", or $CMUX_PANE_ID is set when we're already inside a surface.
+CMUX="$(command -v cmux || echo /Applications/cmux.app/Contents/Resources/bin/cmux)"
+if [ -x "$CMUX" ] && { "$CMUX" tree 2>/dev/null | grep -q '◀ here' || [ -n "$CMUX_PANE_ID" ]; }; then
   PRESENT=cmux
 elif command -v tmux >/dev/null 2>&1; then
   PRESENT=tmux
@@ -79,10 +84,12 @@ WORKFLOW_CAPABLE=$([ "$HOST" = claude ] && echo yes || echo no)
 
 Notes:
 
-- `$CMUX_SOCKET` (and the other `CMUX_*` vars) are set when the session is hosted
-  _inside_ a cmux surface — a stronger signal than `command -v cmux`, which only
-  proves cmux is installed somewhere. Prefer the env var when deciding whether
-  you can spawn a _sibling_ cmux tab.
+- **cmux does not require `$CMUX_SOCKET`.** The `cmux` CLI controls cmux over its
+  Unix socket even when `$CMUX_SOCKET` is unset (Claude Code running inside a
+  cmux-managed tmux session does not inherit it). What you actually need to open a
+  _sibling_ tab is a **target pane**: `cmux tree` marks the orchestrator's own pane
+  `◀ here`, and `$CMUX_PANE_ID` / `$CMUX_WORKSPACE_ID` are set when you're inside a
+  surface. Reachable CLI **and** a resolvable pane ⇒ B1; reachable but no pane ⇒ B2.
 - `$TMUX` (set when already inside a tmux session) and `$CLAUDE_CODE_*` are
   available for finer decisions but are not required for backend selection.
 - **Host knows itself.** A skill is executed by whatever agent loaded it. If you
@@ -138,14 +145,15 @@ git worktree add -b feat/<ws> .feature-workspaces/<ws> main
 > `[ -z "$EXECUTOR" ] && { echo "run detect() — \$EXECUTOR unset"; exit 1; }`
 > so an unset executor aborts loudly instead of launching a bare login shell.
 
-**B1 — session in tmux + cmux tab:**
+**B1 — session in tmux + cmux review tab:**
+
+Spawn the tmux session **only**. The cmux review tab is attached _after_ the
+bootstrap is sent (see "Attach the cmux review tab" below): attaching a surface
+focuses the tmux composer and blocks external `send-keys`, so the prompt must land
+first.
 
 ```bash
 tmux new-session -d -s <ws> -c .feature-workspaces/<ws> "$EXECUTOR"
-GEN_SURFACE=$(cmux new-surface --type terminal | grep -o 'surface:[0-9]*')
-cmux send --surface "$GEN_SURFACE" "tmux attach -t <ws>\n"
-cmux rename-tab --surface "$GEN_SURFACE" "<ws>"
-# bootstrap is sent after readiness (below)
 ```
 
 **B2 — session in tmux, no cmux:**
@@ -171,6 +179,30 @@ else
 fi
 tmux send-keys -t <ws>:0.0 -l -- "$bootstrap_prompt"   # literal text (handles multi-line)
 tmux send-keys -t <ws>:0.0 Enter                       # one submit
+```
+
+**Attach the cmux review tab (B1 only, AFTER the bootstrap).** Open the tab as a
+**sibling in the pane that holds the orchestrator's own tab** — never
+`cmux new-workspace` (that makes a separate top-level workspace) and never a bare
+`cmux new-surface` (it defaults to an unset `$CMUX_WORKSPACE_ID`). Resolve the pane
+from `cmux tree` (the orchestrator's tab is marked `◀ here`), falling back to the
+surface env vars when we're inside one:
+
+```bash
+# $CMUX is the CLI path resolved in detect(). Run this only when PRESENT == cmux.
+read -r WS PANE < <("$CMUX" tree 2>/dev/null | awk '
+  /workspace workspace:/ {for (i=1;i<=NF;i++) if ($i ~ /^workspace:/) ws=$i}
+  /pane pane:/           {for (i=1;i<=NF;i++) if ($i ~ /^pane:/)      pane=$i}
+  /◀ here/               {print ws, pane; exit}')
+: "${WS:=$CMUX_WORKSPACE_ID}" "${PANE:=$CMUX_PANE_ID}"
+if [ -n "$PANE" ]; then                                  # genuine B1 — a target pane exists
+  SREF=$("$CMUX" new-surface --type terminal --workspace "$WS" --pane "$PANE" --focus true \
+         | grep -oE 'surface:[0-9]+' | head -1)
+  "$CMUX" send --surface "$SREF" "tmux attach -t <ws>"$'\n'   # trailing newline submits
+  "$CMUX" rename-tab --surface "$SREF" "<ws>"
+else                                                     # reachable but no pane → degrade to B2
+  echo "cmux reachable but no target pane — headless B2: tmux attach -t <ws>"
+fi
 ```
 
 **B3 — native subagent (no tmux):**
@@ -339,12 +371,12 @@ but does not mutate workspaces:
 
 ### `present(ws)` — human review surface
 
-| Surface       | Recipe                                                                      |
-| ------------- | --------------------------------------------------------------------------- |
-| cmux (B1)     | the cmux tab created in `spawn()` already shows the live session            |
-| tmux (B2)     | tell the human: `tmux attach -t <ws>` (read-only: `tmux attach -t <ws> -r`) |
-| none (B3)     | headless — review via `monitor()` signals and the PR when it lands          |
-| workflow (B4) | the `/workflows` view; plus signals + PR                                    |
+| Surface       | Recipe                                                                              |
+| ------------- | ----------------------------------------------------------------------------------- |
+| cmux (B1)     | the cmux review tab attached at the end of `spawn()` already shows the live session |
+| tmux (B2)     | tell the human: `tmux attach -t <ws>` (read-only: `tmux attach -t <ws> -r`)         |
+| none (B3)     | headless — review via `monitor()` signals and the PR when it lands                  |
+| workflow (B4) | the `/workflows` view; plus signals + PR                                            |
 
 ### `teardown(ws)`
 
@@ -387,11 +419,14 @@ cmux is a **convenience, never a requirement**. Nothing functional depends on
 it; it is purely the human's clickable live-view tab.
 
 ```
-cmux present   → B1: clickable tab, live view
-tmux present   → B2: same session + monitor loop; `tmux attach` to watch
-no multiplexer → B3: headless autonomous subagent; review via signals + PR
+cmux tab attachable → B1: clickable review tab (sibling of the orchestrator's tab), live view
+tmux present        → B2: same session + monitor loop; `tmux attach` to watch
+no multiplexer      → B3: headless autonomous subagent; review via signals + PR
 ```
 
-Losing cmux costs only the tab UI. The file-based monitor loop and mid-flight
-feedback survive in B2 unchanged. Skills must therefore gate every cmux call on
-detection and never abort merely because cmux is absent.
+"cmux tab attachable" = the `cmux` CLI is reachable **and** a target pane resolves
+(`cmux tree` shows `◀ here`, or `$CMUX_PANE_ID` is set) — it does **not** require
+`$CMUX_SOCKET`. Reachable-but-no-pane degrades to B2; losing cmux costs only the
+tab UI. The file-based monitor loop and mid-flight feedback survive in B2
+unchanged. Skills must therefore gate every cmux call on detection and never abort
+merely because cmux is absent.


### PR DESCRIPTION
Fixes how `aep-launch` / `aep-executor` attach a cmux review surface. Three bugs, reported and verified live from a downstream (looplia) session.

## Bugs fixed
1. **Detection gated on `$CMUX_SOCKET`** → a host where the `cmux` CLI is reachable but `$CMUX_SOCKET` is unset (Claude Code inside a cmux-managed tmux session) wrongly fell back to headless B2. Detection now keys on **cmux CLI reachable AND a target pane resolves** (`cmux tree` `◀ here` / `$CMUX_PANE_ID`), independent of `$CMUX_SOCKET`.
2. **Wrong tab placement** → the bare `cmux new-surface` defaulted to an unset `$CMUX_WORKSPACE_ID`. Now `/launch` resolves the orchestrator's own pane from `cmux tree` and opens a **sibling tab** via `new-surface --workspace <ws> --pane <pane> --focus true`. `cmux new-workspace` (separate top-level workspace) is kept out of the launch path.
3. **Bootstrap lost** → an attached cmux surface focuses the tmux composer and blocks external `send-keys`, so the bootstrap couldn't land. Reordered: spawn tmux → wait ready → send bootstrap via `tmux send-keys` → **then** attach the cmux tab.

## Files
- `skills/agentic-development-workflow/launch/SKILL.md` — Spawn (defer cmux), Send Bootstrap (always tmux), new "Attach the cmux Review Tab (B1)" step
- `skills/patterns/executor/references/backends.md` — detection, B1 recipe, `present()`, fallback ladder
- `skills/patterns/executor/SKILL.md` — detection summary
- `marketplace.json` 1.3.1 → 1.3.2 + `CHANGELOG.md` [1.3.2]

## Acceptance
- cmux running but `$CMUX_SOCKET` unset → review tab opens in the orchestrator's current cmux project pane (beside its own tab), not a new top-level workspace and not silent headless tmux.
- The build agent receives its bootstrap (sent before the surface attached).
- No `cmux new-workspace` in the launch path.

> Note: the cmux verbs were verified live in the reporting session; the integration here should be confirmed on an actual cmux host before relying on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)