### PR TITLE
docs(readme): add AGENTS.md pin-note bump to upgrade steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,9 +150,14 @@ Then:
    files your old pin predated — expect more new files than the changelog's headline.
 2. **Normalize `.claude/skills/aep-*` back to symlinks** if your layout shares one copy between
    runtimes (see the gotcha below).
-3. **Commit with `--no-verify`** so the pre-commit formatter doesn't rewrite the pinned bytes and
+3. **Bump the AGENTS.md pin note.** If your `AGENTS.md` states the pinned version in prose — the
+   canonical header's `… pinned at **vX.Y.Z**) are self-describing …` line — update it to the new
+   tag so the doc doesn't drift from the installed bytes. It's hand-written, so the skill install
+   won't touch it. Stage it in the **same commit** as the skill bytes.
+4. **Commit with `--no-verify`** so the pre-commit formatter doesn't rewrite the pinned bytes and
    break the lockfile hashes (see [Keep your formatter off the skills](#keep-your-formatter-off-the-skills)).
-4. **Verify.** `npx skills list` shows the new versions and `git status` is clean.
+5. **Verify.** `npx skills list` shows the new versions, the AGENTS.md pin note matches the new tag,
+   and `git status` is clean.
 
 > **Gotcha — the `-a claude-code` symlink copy.** If your canonical layout keeps
 > `.agents/skills/<name>` as the **real files** and `.claude/skills/<name>` as a **symlink** →


### PR DESCRIPTION
## What

The README `### Upgrading to a new release` section listed four steps (review diff → normalize symlinks → `--no-verify` commit → verify) but **never said to update the canonical AGENTS.md `pinned at **vX.Y.Z**` prose line**.

## Why

That line is hand-written — the `skills add` install never touches it — so it silently drifts from the installed skill bytes on every re-pin. Hit this directly during the v1.7.0 → v2.0.1 downstream sweep: all repos' skill bytes were v2.0.1 while AGENTS.md still said `pinned at **v1.7.0**`.

## Change

- New explicit step **③ Bump the AGENTS.md pin note** (before the commit, so it lands in the same commit as the skill bytes).
- Folded the pin-note match into the **verify** step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)