### PR TITLE
feat(aep): add /aep-workflow dynamic-workflow pattern (v2.2.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
     "email": "mho@looplia.run"
   },
   "metadata": {
-    "version": "2.1.0",
+    "version": "2.2.0",
     "description": "Skills for product planning, project scaffolding, and agentic development workflows."
   },
   "plugins": [
@@ -51,13 +51,14 @@
     },
     {
       "name": "patterns",
-      "description": "Reusable design patterns: gen/eval, executor abstraction, autopilot orchestration, workflow-feedback.",
+      "description": "Reusable design patterns: gen/eval, executor abstraction, autopilot orchestration, dynamic workflows, workflow-feedback.",
       "source": "./",
       "strict": false,
       "skills": [
         "./skills/patterns/gen-eval",
         "./skills/patterns/executor",
         "./skills/patterns/autopilot",
+        "./skills/patterns/workflow",
         "./skills/patterns/workflow-feedback"
       ]
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,41 @@ bug fixes → **patch**; removing or breaking a skill contract → **major**.
 
 _Nothing yet._
 
+## [2.2.0] - 2026-06-23
+
+Add a **dynamic-workflow pattern** — `/aep-workflow` — that codifies "a harness for
+every task": when (and when not) to have Claude write a custom multi-agent harness
+for a task, plus the reusable sub-pattern catalog (classify-and-route,
+fan-out-and-synthesize, adversarial verification, generate-and-filter, tournament,
+loop-until-done). It frames workflows as a structural fix for three failure modes of
+long single-context work — agentic laziness, self-preferential bias, and goal drift —
+and cross-links the narrow `aep-executor` `workflow` backend, `/aep-gen-eval`
+(adversarial verification), and `/aep-autopilot` (the long-lived loop) rather than
+duplicating them. Source and rationale:
+[`docs/research/dynamic-workflows.md`](docs/research/dynamic-workflows.md).
+
+### Added
+
+- **`/aep-workflow` skill** (`patterns`): dual library + standalone skill (same shape
+  as `/aep-gen-eval`) covering the failure modes, the "should I even use a workflow"
+  judgment, invocation (`ultracode`, "…with workflow", `/loop` + `/goal`, token
+  budgets, save-as-template), and the AEP touchpoints. Registered in
+  [`marketplace.json`](.claude-plugin/marketplace.json) `patterns` plugin.
+- **Sub-pattern catalog** (`patterns/workflow/references/pattern-catalog.md`): the six
+  sub-patterns with intent, the Workflow primitive to use (`parallel` barrier vs
+  `pipeline` no-barrier vs loop), AEP examples, and skeletons; plus architectural
+  levers (per-agent model, worktree isolation, quarantine, token budgets, resumability).
+- **Research note** `docs/research/dynamic-workflows.md` (linked from the README
+  Documentation list).
+
+### Changed
+
+- **`/aep-executor`** (SKILL.md + `references/backends.md`): the narrow "Mode:
+  workflow" now points to `/aep-workflow` for the general pattern catalog and the
+  "when to reach for a workflow" judgment.
+- **`/aep-gen-eval`**: notes that adversarial verification in `/aep-workflow` is the
+  generalized, N-verifier form of generator/evaluator separation.
+
 ## [2.1.0] - 2026-06-16
 
 Add an **object-first design stage** — `/aep-model` — that turns the verb-first

--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ The `skills` CLI selects by skill name (there's no "group" flag). The groups map
 | **Workflow** (agentic-development-workflow) | `aep-design`, `aep-launch`, `aep-build`, `aep-wrap`, `aep-git-ref`                                     |
 | **Product** (product-context)               | `aep-envision`, `aep-map`, `aep-model`, `aep-dispatch`, `aep-validate`, `aep-calibrate`, `aep-reflect` |
 | **Setup** (project-setup)                   | `aep-onboard`, `aep-scaffold`, `aep-testing-guide`                                                     |
-| **Patterns** (patterns)                     | `aep-gen-eval`, `aep-executor`, `aep-autopilot`, `aep-workflow-feedback`                               |
+| **Patterns** (patterns)                     | `aep-gen-eval`, `aep-executor`, `aep-autopilot`, `aep-workflow`, `aep-workflow-feedback`               |
 
 > **Releasing:** bumping `metadata.version` in `.claude-plugin/marketplace.json` must come with a matching [CHANGELOG.md](CHANGELOG.md) entry in the same PR (move the `[Unreleased]` notes under the new `[X.Y.Z] - DATE` heading), and a `vX.Y.Z` git tag on merge to `main`.
 
@@ -571,7 +571,7 @@ These aren't rules we invented — they're patterns extracted from Anthropic's e
 
 ## Getting Started
 
-**Brand new to AEP?** Start with the [Orientation Guide](docs/orientation.md) for a 10-minute tour of the mental models, the 19 skills, and the four paths — then run `/aep-onboard`.
+**Brand new to AEP?** Start with the [Orientation Guide](docs/orientation.md) for a 10-minute tour of the mental models, the 20 skills, and the four paths — then run `/aep-onboard`.
 
 **New to this plugin?**
 
@@ -643,6 +643,7 @@ Generate a dimension-specific brief, explore or discuss, capture decisions for a
 | `/aep-gen-eval`  | patterns                     | Generator/evaluator separation for honest validation                                                        |
 | `/aep-executor`  | patterns                     | Host-agnostic backend for spawning/steering workspace agents                                                |
 | `/aep-autopilot` | patterns                     | Autonomous dispatch-launch-monitor-wrap loop via `/loop`                                                    |
+| `/aep-workflow`  | patterns                     | Dynamic workflows — author a custom multi-agent harness for a task (+ sub-pattern catalog)                  |
 
 Launches are **native-first** with **hub-and-spoke human gates** — see
 [Launch modes](#launch-modes--native-first-executor-backends) and
@@ -657,6 +658,7 @@ block-in-place / gate-and-park strategy.
 - [Skills Quick Reference](docs/skills-quick-reference.md) — when to use which skill, decision trees, common sequences
 - [Autonomous Loop](docs/autonomous-loop.md) — how `/aep-autopilot` orchestrates the full cycle
 - [Generator/Evaluator Data Flow](docs/gen-eval-data-flow.md) — the three tracking systems and signal protocol
+- [Dynamic Workflows](docs/research/dynamic-workflows.md) — the "harness for every task" idea, the failure modes it counters, and why `/aep-workflow` exists
 - [Release Line Adjustments](docs/release-line-adjustments.md) — when and how to re-slice layers
 - [Design Calibration Workflow](docs/decisions/design-calibration-workflow.md) — the original visual-design `/aep-calibrate` skill
 - [Generalized Calibration Workflow](docs/decisions/generalized-calibration-workflow.md) — multi-dimension `/aep-calibrate` and `.5` alignment layers

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -321,6 +321,14 @@ The pre-assembled directory of context files created by `/aep-dispatch` for each
 
 See also: **Context Assembly**, **Stable Prefix**, **OpenSpec Change**
 
+### Dynamic Workflow
+
+A **Harness** that Claude writes itself, on the fly, for a single task — a deterministic JS script (the Claude Code _Workflow_ tool) that spawns and coordinates context-isolated subagents, instead of running the task in the one default coding harness. Used to counter agentic laziness, self-preferential bias, and goal drift on large/unbounded work. Has a catalog of sub-patterns (classify-route, fan-out/synthesize, adversarial verify, generate-filter, tournament, loop-until-done). Distinct from **Workflow Feedback**.
+
+**Where it appears:** `/aep-workflow` skill; `/aep-executor` `workflow` backend mode; invoked via `ultracode` or "…with workflow".
+
+See also: **Harness**, **Generator/Evaluator Separation**, **Orchestrator**
+
 ### Evaluator
 
 The separate agent that reviews a **Generator**'s work. Calibrated toward skepticism because agents praise their own work. Scores across dimensions (e.g., Completeness, Correctness, UX Quality, Security, Code Quality) on a 1–5 scale with hard failure thresholds. Spawned at **Phase** 5 by the generator via `executor.spawn_evaluator()` (foreground Task subagent, `codex exec --cd`, or tmux split per launch mode), not at launch.
@@ -371,7 +379,7 @@ The infrastructure surrounding an agent to help it succeed — tracking files, s
 | No visibility into progress     | status.json               | Signal files                    |
 | No mid-flight course correction | feedback.md               | Main session sends instructions |
 
-See also: **Generator/Evaluator Separation**, **Sprint Contract**, **Feature Verification**
+See also: **Dynamic Workflow** (a harness Claude writes per-task), **Generator/Evaluator Separation**, **Sprint Contract**, **Feature Verification**
 
 ### Orchestrator
 

--- a/docs/orientation.md
+++ b/docs/orientation.md
@@ -1,6 +1,6 @@
 # AEP Orientation Guide
 
-**A 10-minute first-hour tour for new users.** Read this before (or right after) running `/aep-onboard`. When you finish, you'll know what AEP is, the three mental models that drive every skill, what each of the 19 skills does, and which of four concrete paths matches your situation.
+**A 10-minute first-hour tour for new users.** Read this before (or right after) running `/aep-onboard`. When you finish, you'll know what AEP is, the three mental models that drive every skill, what each of the 20 skills does, and which of four concrete paths matches your situation.
 
 For precise definitions of every term used here, see the [Glossary](glossary.md). For a one-page decision tree, see the [Skills Quick Reference](skills-quick-reference.md).
 
@@ -94,29 +94,30 @@ More: [README.md "The Feature Lifecycle"](../README.md) and [skills/agentic-deve
 
 ---
 
-## 3. The 19 Skills at a Glance
+## 3. The 20 Skills at a Glance
 
-| Skill                    | Plugin                       | Session   | Purpose                                                          |
-| ------------------------ | ---------------------------- | --------- | ---------------------------------------------------------------- |
-| `/aep-onboard`           | project-setup                | Main      | Install tools, verify env, configure plugins, orient new users   |
-| `/aep-scaffold`          | project-setup                | Main      | Scaffold a full-stack TypeScript monorepo + initialize OpenSpec  |
-| `/aep-testing-guide`     | project-setup                | Main      | Reference for workspace-level quality infrastructure             |
-| `/aep-envision`          | product-context              | Main      | Opportunity brief + context document (what to build)             |
-| `/aep-map`               | product-context              | Main      | System map + story graph + agent topology (how to decompose)     |
-| `/aep-model`             | product-context              | Main      | Object-first UI structure (OOUX/ORCA Object Map) for UI products |
-| `/aep-validate`          | product-context              | Main      | Generator/evaluator validation of any AEP artifact               |
-| `/aep-dispatch`          | product-context              | Main      | Pick next story + create OpenSpec change + hand off              |
-| `/aep-calibrate`         | product-context              | Main      | Human alignment checkpoint for any quality dimension             |
-| `/aep-reflect`           | product-context              | Main      | Classify feedback + update context (close the loop)              |
-| `/aep-watch`             | product-context              | Main      | Ingest telemetry/errors → auto-file stories (self-feeding loop)  |
-| `/aep-design`            | agentic-development-workflow | Main      | Interactive feature design (explore + propose + review)          |
-| `/aep-launch`            | agentic-development-workflow | Main      | Spawn autonomous workspace + optional evaluator                  |
-| `/aep-build`             | agentic-development-workflow | Workspace | Implement → test → PR → merge (autonomous)                       |
-| `/aep-wrap`              | agentic-development-workflow | Main      | Post-merge archive + cleanup + update story status               |
-| `/aep-git-ref`           | agentic-development-workflow | Main      | AEP git + worktree conventions (on-demand)                       |
-| `/aep-autopilot`         | patterns                     | Main      | Hands-free dispatch → launch → monitor → wrap loop               |
-| `/aep-gen-eval`          | patterns                     | Both      | Reusable generator/evaluator pattern for honest evaluation       |
-| `/aep-workflow-feedback` | patterns                     | Main      | Capture + review process learnings from builds                   |
+| Skill                    | Plugin                       | Session   | Purpose                                                           |
+| ------------------------ | ---------------------------- | --------- | ----------------------------------------------------------------- |
+| `/aep-onboard`           | project-setup                | Main      | Install tools, verify env, configure plugins, orient new users    |
+| `/aep-scaffold`          | project-setup                | Main      | Scaffold a full-stack TypeScript monorepo + initialize OpenSpec   |
+| `/aep-testing-guide`     | project-setup                | Main      | Reference for workspace-level quality infrastructure              |
+| `/aep-envision`          | product-context              | Main      | Opportunity brief + context document (what to build)              |
+| `/aep-map`               | product-context              | Main      | System map + story graph + agent topology (how to decompose)      |
+| `/aep-model`             | product-context              | Main      | Object-first UI structure (OOUX/ORCA Object Map) for UI products  |
+| `/aep-validate`          | product-context              | Main      | Generator/evaluator validation of any AEP artifact                |
+| `/aep-dispatch`          | product-context              | Main      | Pick next story + create OpenSpec change + hand off               |
+| `/aep-calibrate`         | product-context              | Main      | Human alignment checkpoint for any quality dimension              |
+| `/aep-reflect`           | product-context              | Main      | Classify feedback + update context (close the loop)               |
+| `/aep-watch`             | product-context              | Main      | Ingest telemetry/errors → auto-file stories (self-feeding loop)   |
+| `/aep-design`            | agentic-development-workflow | Main      | Interactive feature design (explore + propose + review)           |
+| `/aep-launch`            | agentic-development-workflow | Main      | Spawn autonomous workspace + optional evaluator                   |
+| `/aep-build`             | agentic-development-workflow | Workspace | Implement → test → PR → merge (autonomous)                        |
+| `/aep-wrap`              | agentic-development-workflow | Main      | Post-merge archive + cleanup + update story status                |
+| `/aep-git-ref`           | agentic-development-workflow | Main      | AEP git + worktree conventions (on-demand)                        |
+| `/aep-autopilot`         | patterns                     | Main      | Hands-free dispatch → launch → monitor → wrap loop                |
+| `/aep-gen-eval`          | patterns                     | Both      | Reusable generator/evaluator pattern for honest evaluation        |
+| `/aep-workflow`          | patterns                     | Main      | Dynamic workflows — write a custom multi-agent harness for a task |
+| `/aep-workflow-feedback` | patterns                     | Main      | Capture + review process learnings from builds                    |
 
 For when-to-use decisions, see [docs/skills-quick-reference.md](skills-quick-reference.md).
 

--- a/docs/research/dynamic-workflows.md
+++ b/docs/research/dynamic-workflows.md
@@ -1,0 +1,120 @@
+# Dynamic Workflows — "a harness for every task" × AEP
+
+> **Status:** Research note + rationale for the `/aep-workflow` pattern (shipped).
+> Records the source idea, the failure modes it targets, the sub-pattern catalog,
+> and _why AEP adds it as a first-class pattern_ rather than relying on the
+> `aep-executor` `workflow` backend mode alone.
+> **Date:** 2026-06-23
+> **Source:** Thariq Shihipar & Sid Bidasaria (Anthropic), _"A harness for every
+> task: dynamic workflows in Claude Code."_ Original X post
+> (`x.com/trq212/status/2061907337154367865`) links to the canonical article on
+> claude.com. The X article body is login-gated, so the full text was recovered
+> from the official post:
+> <https://claude.com/blog/a-harness-for-every-task-dynamic-workflows-in-claude-code>
+> (fetched via WebSearch + WebFetch — mgrep `--web` quota was exhausted this month).
+
+---
+
+## 0. TL;DR
+
+- A **dynamic workflow** is a harness Claude **writes itself** for one task: a
+  deterministic JS script (the Claude Code _Workflow_ tool) that spawns and
+  coordinates context-isolated subagents, custom-built for the task — instead of
+  running everything in the single default coding harness.
+- It exists to counter three failure modes of long single-context work:
+  **agentic laziness**, **self-preferential bias**, and **goal drift**.
+- It is not a default wrapper. The article's own guardrail: _most traditional
+  coding tasks do not need a panel of 5 reviewers_ — workflows cost significantly
+  more tokens, so ask "does this really need more compute?"
+- AEP already used dynamic workflows **narrowly** (one dispatched build wave =
+  one Workflow script, in `aep-executor`'s `workflow` mode). The gap was a
+  **general pattern** capturing the broader idea and the "when to reach for one"
+  judgment. `/aep-workflow` fills it.
+
+---
+
+## 1. What a harness is, and what changed
+
+A _harness_ is the scaffolding around the model — the part that decides how a task
+is planned, divided, checked, and executed. Claude Code ships one default harness,
+built for coding. With Opus 4.8 + dynamic workflows, Claude can author a **new
+harness on the fly**, tailored to the task, and run it as a Workflow: a JS file
+with a few special functions (`agent`, `parallel`, `pipeline`, `phase`, `log`,
+`budget`) that spawn subagents and merge their structured outputs.
+
+The leverage is **structural**: many small agents, each with a clean context and a
+focused goal, coordinated by deterministic control flow — rather than one long
+transcript that has to hold everything.
+
+## 2. The three failure modes (why it earns its place)
+
+AEP design principle #3: _every harness component earns its place — each exists
+because of a specific failure mode._ The article names three:
+
+1. **Agentic laziness** — Claude stops before finishing a complex multi-part task
+   and declares it done after partial progress (e.g. 35 of 50 security-review
+   items). → Fan-out (one agent per item) + a `loop-until-done` stop condition.
+2. **Self-preferential bias** — Claude prefers / passes its own results when asked
+   to verify or judge them against a rubric. → A _separate_ verifier agent. This is
+   the same insight AEP already encodes in `/aep-gen-eval`; workflows generalize it
+   to N independent verifiers/refuters.
+3. **Goal drift** — gradual loss of fidelity to the original objective across many
+   turns, especially after compaction; each summarization is lossy, and "don't do
+   X" constraints get dropped. → Short, focused goals in fresh contexts that never
+   have to survive a long lossy history.
+
+## 3. The sub-pattern catalog
+
+Codified in
+[`skills/patterns/workflow/references/pattern-catalog.md`](../../skills/patterns/workflow/references/pattern-catalog.md):
+
+1. **Classify-and-route** — classifier picks task type / model tier, then routes.
+2. **Fan-out-and-synthesize** — split → agent per step → barrier merges results.
+3. **Adversarial verification** — separate agent refutes each output vs a rubric.
+4. **Generate-and-filter** — many candidates → dedupe → keep rubric-passers.
+5. **Tournament** — N approaches compete; pairwise judging until a winner.
+6. **Loop-until-done** — spawn until a stop condition, not a fixed pass count.
+
+Plus architectural levers: per-agent model choice, worktree isolation, **quarantine**
+(untrusted-content readers barred from high-privilege actions), token budgets, and
+resumability. These compose — a thorough review is fan-out → adversarial verify →
+loop-until-dry.
+
+## 4. How it's invoked
+
+- Ask Claude to "set up / use a workflow…".
+- The **`ultracode`** keyword forces a workflow.
+- Inside AEP, **"…with workflow"** routes a dispatched build wave through
+  `aep-executor`'s `workflow` mode.
+- Pair with **`/loop`** (recurring), **`/goal`** (hard completion requirement,
+  counters laziness), and **token budgets** ("use 10k tokens"). Workflows are
+  saveable (`s` in the menu → `~/.claude/workflows`) and shareable via a skill —
+  best treated as a _template_, not a verbatim script.
+
+## 5. Why a pattern in AEP, not just the executor mode
+
+`aep-executor` already had a `workflow` backend, but it is scoped to one thing: run
+a dispatched _build_ wave as a fan-out (see
+[`skills/patterns/executor/references/backends.md`](../../skills/patterns/executor/references/backends.md)
+→ _Mode: workflow_). The article's idea is much broader — verification, tournaments,
+research, triage, evals, sorting at scale — and the most valuable thing to capture
+is the **judgment of when a task warrants a workflow at all**. That belongs in a
+first-class, discoverable pattern (`/aep-workflow`), cross-linked to the executor
+mode and to `/aep-gen-eval` (the canonical adversarial-verification implementation)
+and `/aep-autopilot` (the long-lived loop), rather than buried in one backend.
+
+## 6. Decision in this change
+
+- **Ship** `/aep-workflow` in the `patterns` group as a dual library + standalone
+  skill, mirroring `/aep-gen-eval`'s shape.
+- **Do not** duplicate gen-eval's scoring or autopilot's loop machinery — point to
+  them. The new skill owns the catalog + the "when (not) to use" guardrail.
+- **Do not** change the Workflow tool or executor selection logic — documentation
+  cross-links only.
+
+## Sources
+
+- Thariq Shihipar & Sid Bidasaria, Anthropic — _A harness for every task: dynamic
+  workflows in Claude Code_ —
+  <https://claude.com/blog/a-harness-for-every-task-dynamic-workflows-in-claude-code>
+- X post: <https://x.com/trq212/status/2061907337154367865> (login-gated body).

--- a/docs/skills-quick-reference.md
+++ b/docs/skills-quick-reference.md
@@ -40,11 +40,12 @@ CONTROL PLANE (human + AI)              EXECUTION PLANE (agents build)
 
 ### Patterns (Reusable)
 
-| Skill                    | When to use                           | Input                                          | Output                                     | Session |
-| ------------------------ | ------------------------------------- | ---------------------------------------------- | ------------------------------------------ | ------- |
-| `/aep-gen-eval`          | Run honest evaluation on any artifact | Artifact to evaluate + dimension selection     | Scoring results + findings                 | Both    |
-| `/aep-autopilot`         | Hands-free autonomous orchestration   | `product-context.yaml` with ready stories      | Continuous dispatch → build → wrap cycle   | Main    |
-| `/aep-workflow-feedback` | Capture or review process learnings   | Lessons from builds, downstream feedback files | Classified feedback in standardized format | Main    |
+| Skill                    | When to use                                                                 | Input                                                              | Output                                                              | Session |
+| ------------------------ | --------------------------------------------------------------------------- | ------------------------------------------------------------------ | ------------------------------------------------------------------- | ------- |
+| `/aep-gen-eval`          | Run honest evaluation on any artifact                                       | Artifact to evaluate + dimension selection                         | Scoring results + findings                                          | Both    |
+| `/aep-autopilot`         | Hands-free autonomous orchestration                                         | `product-context.yaml` with ready stories                          | Continuous dispatch → build → wrap cycle                            | Main    |
+| `/aep-workflow`          | Author a custom multi-agent harness for a large/uncertain/verify-heavy task | A task too big, drift-prone, or verification-heavy for one context | A dynamic workflow (fan-out, verify, tournament, loop) + its result | Main    |
+| `/aep-workflow-feedback` | Capture or review process learnings                                         | Lessons from builds, downstream feedback files                     | Classified feedback in standardized format                          | Main    |
 
 ### Project Setup (Run Once)
 
@@ -77,6 +78,8 @@ CONTROL PLANE (human + AI)              EXECUTION PLANE (agents build)
 "Create a new project"              → /aep-scaffold
 "Set up testing infrastructure"     → /aep-testing-guide
 "Evaluate this honestly"            → /aep-gen-eval
+"Write a custom harness / workflow" → /aep-workflow
+"This is too big for one context"   → /aep-workflow
 ```
 
 ---

--- a/skills/patterns/README.md
+++ b/skills/patterns/README.md
@@ -2,11 +2,13 @@
 
 Reusable design patterns extracted from the AEP workflow. These are utility skills — both directly invokable and referenceable by other skills.
 
-| Pattern                         | What it does                                                                                                                                          | Used by                                                                |
-| ------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
-| [gen-eval](gen-eval/SKILL.md)   | Generator/evaluator separation for honest artifact validation                                                                                         | `/aep-build` Phase 5, `/aep-launch` evaluator setup, `/aep-validate`   |
-| [executor](executor/SKILL.md)   | Host-agnostic launch modes for spawning/steering workspace agents (Claude teams/bg sessions; Codex subagents/exec; tmux when pinned; workflow opt-in) | `/aep-launch`, `/aep-build` Phase 5, `/aep-autopilot`, `/aep-dispatch` |
-| [autopilot](autopilot/SKILL.md) | Tick-based autonomous orchestration of dispatch-launch-monitor-review-wrap cycle                                                                      | `/loop`, orchestrates `/aep-dispatch`, `/aep-launch`, `/aep-wrap`      |
+| Pattern                                         | What it does                                                                                                                                                                                       | Used by                                                                          |
+| ----------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
+| [gen-eval](gen-eval/SKILL.md)                   | Generator/evaluator separation for honest artifact validation                                                                                                                                      | `/aep-build` Phase 5, `/aep-launch` evaluator setup, `/aep-validate`             |
+| [executor](executor/SKILL.md)                   | Host-agnostic launch modes for spawning/steering workspace agents (Claude teams/bg sessions; Codex subagents/exec; tmux when pinned; workflow opt-in)                                              | `/aep-launch`, `/aep-build` Phase 5, `/aep-autopilot`, `/aep-dispatch`           |
+| [autopilot](autopilot/SKILL.md)                 | Tick-based autonomous orchestration of dispatch-launch-monitor-review-wrap cycle                                                                                                                   | `/loop`, orchestrates `/aep-dispatch`, `/aep-launch`, `/aep-wrap`                |
+| [workflow](workflow/SKILL.md)                   | Dynamic workflows — when to write a custom multi-agent harness for a task, and the sub-pattern catalog (fan-out, adversarial verify, tournament, loop-until-done, classify-route, generate-filter) | `/aep-executor` workflow mode, `/aep-gen-eval`, `/aep-validate`, `/aep-dispatch` |
+| [workflow-feedback](workflow-feedback/SKILL.md) | Capture process learnings about the AEP workflow itself (distinct from product feedback)                                                                                                           | `/aep-workflow-feedback capture` / `review`                                      |
 
 ## Why Patterns Exist
 
@@ -37,6 +39,8 @@ After sync with `aep-` prefix, pattern files are at:
 .claude/skills/aep-autopilot/references/orchestration-learning.md
 
 .claude/skills/aep-executor/references/backends.md
+
+.claude/skills/aep-workflow/references/pattern-catalog.md
 ```
 
 Skills reference them via these paths in their instructions.

--- a/skills/patterns/executor/SKILL.md
+++ b/skills/patterns/executor/SKILL.md
@@ -103,15 +103,15 @@ per mode.
 
 ## The Modes (summary)
 
-| Mode                   | Backend                                 | Lifetime      | Selected when                                                       |
-| ---------------------- | --------------------------------------- | ------------- | ------------------------------------------------------------------- |
-| **native-bg-subagent** | Agent tool `run_in_background`, no team | session-bound | **Claude Code default** + long-lived orchestrator                   |
-| **claude-bg**          | native background sessions              | OS-bound      | Claude Code, `claude --bg` present (cron driver / OS-bound need)    |
-| **codex-subagent**     | native multi_agent (`spawn_agent`)      | session-bound | Codex with a living main thread (desktop app or interactive CLI)    |
-| **codex-exec**         | headless `codex exec --cd` workers      | OS-bound      | Codex + cron driver, or hard isolation demanded                     |
-| **legacy**             | tmux session (+ optional cmux tab)      | OS-bound      | explicit pin (`aep.executor-backend tmux`), or generic host w/ tmux |
-| **workflow**           | CC dynamic-workflow fan-out             | session-bound | explicit opt-in ("…with workflow") + Claude Code                    |
-| **headless**           | one-shot native subagent                | session-bound | last resort                                                         |
+| Mode                   | Backend                                 | Lifetime      | Selected when                                                          |
+| ---------------------- | --------------------------------------- | ------------- | ---------------------------------------------------------------------- |
+| **native-bg-subagent** | Agent tool `run_in_background`, no team | session-bound | **Claude Code default** + long-lived orchestrator                      |
+| **claude-bg**          | native background sessions              | OS-bound      | Claude Code, `claude --bg` present (cron driver / OS-bound need)       |
+| **codex-subagent**     | native multi_agent (`spawn_agent`)      | session-bound | Codex with a living main thread (desktop app or interactive CLI)       |
+| **codex-exec**         | headless `codex exec --cd` workers      | OS-bound      | Codex + cron driver, or hard isolation demanded                        |
+| **legacy**             | tmux session (+ optional cmux tab)      | OS-bound      | explicit pin (`aep.executor-backend tmux`), or generic host w/ tmux    |
+| **workflow**           | CC dynamic-workflow fan-out             | session-bound | explicit opt-in ("…with workflow") + Claude Code (see `/aep-workflow`) |
+| **headless**           | one-shot native subagent                | session-bound | last resort                                                            |
 
 Read `references/backends.md` for the detection recipe, the full selection
 order, the driver × backend compatibility matrix, the human-gate protocol, and

--- a/skills/patterns/executor/references/backends.md
+++ b/skills/patterns/executor/references/backends.md
@@ -399,6 +399,12 @@ as **waiting, not stuck and not failed**.
 
 ## Mode: workflow (dynamic-workflow fan-out)
 
+> This mode is the **narrow** use of dynamic workflows — running one dispatched
+> build wave as a fan-out. For the general dynamic-workflow pattern catalog
+> (classify-route, fan-out/synthesize, adversarial verify, generate-filter,
+> tournament, loop-until-done) and the judgment of _when a task warrants a workflow
+> at all_, see [`/aep-workflow`](../../workflow/SKILL.md).
+
 Claude Code's Workflow tool builds a whole dispatched wave as one deterministic
 fan-out: one build agent per locked story, each with per-agent worktree
 isolation, with `/aep-dispatch` authoring the script (the "…with workflow"

--- a/skills/patterns/gen-eval/SKILL.md
+++ b/skills/patterns/gen-eval/SKILL.md
@@ -50,6 +50,12 @@ Why:
 3. Separate evaluation catches issues the generator is blind to
 4. The cost of a second agent is trivial compared to shipping broken work
 
+> **Scaling up:** generator/evaluator is the canonical instance of _adversarial
+> verification_. When one task produces many findings/claims that each need an
+> independent check, [`/aep-workflow`](../workflow/SKILL.md) generalizes this to a
+> fan-out of N verifiers/refuters — reusing this skill's scoring framework and
+> findings format per finding.
+
 ---
 
 ## Reference Files

--- a/skills/patterns/workflow/SKILL.md
+++ b/skills/patterns/workflow/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: aep-workflow
 description: |-
-  Reusable pattern for authoring a dynamic workflow — a custom multi-agent harness Claude writes on the fly for one task, run as a Claude Code Workflow (a deterministic JS script that spawns and coordinates context-isolated subagents). This is a utility skill — it provides the sub-pattern catalog (classify-and-route, fan-out-and-synthesize, adversarial verification, generate-and-filter, tournament, loop-until-done) and the "when to reach for a workflow" judgment used by /aep-dispatch, /aep-validate, /aep-gen-eval, and /aep-executor. Use directly when a task is large, uncertain, needs adversarial verification, or runs at scale and the default single-context harness would be lazy, biased, or drift off-goal. Triggers on "dynamic workflow", "ultracode", "write a harness", "harness for this task", "fan out agents", "orchestrate subagents", "tournament", "loop until done", "adversarial verify", "panel of agents". NOT for capturing process feedback — that is /aep-workflow-feedback.
+  Reusable pattern for authoring a dynamic workflow — a custom multi-agent harness Claude writes on the fly for one task, run as a Claude Code Workflow (a deterministic JS script that spawns and coordinates context-isolated subagents). This is a utility skill — it provides the sub-pattern catalog (classify-and-route, fan-out-and-synthesize, adversarial verification, generate-and-filter, tournament, loop-until-done) and the "when to reach for a workflow" judgment. Cross-linked from /aep-gen-eval and /aep-executor; relevant when /aep-dispatch or /aep-validate work would benefit from a per-task harness. Use directly when a task is large, uncertain, needs adversarial verification, or runs at scale and the default single-context harness would be lazy, biased, or drift off-goal. Triggers on "dynamic workflow", "ultracode", "write a harness", "harness for this task", "…with workflow", "orchestrate subagents". NOT for capturing process feedback — that is /aep-workflow-feedback.
 ---
 
 # Dynamic Workflow Pattern
@@ -55,14 +55,14 @@ Pick the shape that matches the task. Full intent, the Workflow primitive to use
 (`parallel` barrier vs `pipeline` no-barrier vs loop), AEP examples, and skeletons
 are in [`references/pattern-catalog.md`](references/pattern-catalog.md).
 
-| Sub-pattern                  | One-liner                                                                              | AEP instance                                                     |
-| ---------------------------- | -------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
-| **Classify-and-route**       | A classifier agent decides the task type / model tier, then routes.                    | `/aep-dispatch` story-type routing, model routing                |
-| **Fan-out-and-synthesize**   | Split into many small steps → one agent each → a barrier merges results.               | `/aep-executor` `workflow` mode (one agent per story)            |
-| **Adversarial verification** | For each output, a separate agent tries to refute it against a rubric.                 | `/aep-gen-eval` (generator/evaluator) generalized to N verifiers |
-| **Generate-and-filter**      | Generate many candidates → dedupe → keep only rubric-passing ones.                     | naming / design option generation                                |
-| **Tournament**               | N approaches compete; pairwise judging until a winner (comparative > absolute).        | taste-based decisions (naming, design direction)                 |
-| **Loop-until-done**          | Keep spawning until a stop condition (no new findings / no errors), not a fixed count. | `/aep-autopilot` tick loop is the long-lived cousin              |
+| Sub-pattern                  | One-liner                                                                              | AEP instance                                                      |
+| ---------------------------- | -------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
+| **Classify-and-route**       | A classifier agent decides the task type / model tier, then routes.                    | `/aep-dispatch` readiness-score routing + "…with workflow" opt-in |
+| **Fan-out-and-synthesize**   | Split into many small steps → one agent each → a barrier merges results.               | `/aep-executor` `workflow` mode (one agent per story)             |
+| **Adversarial verification** | For each output, a separate agent tries to refute it against a rubric.                 | `/aep-gen-eval` (generator/evaluator) generalized to N verifiers  |
+| **Generate-and-filter**      | Generate many candidates → dedupe → keep only rubric-passing ones.                     | naming / design option generation                                 |
+| **Tournament**               | N approaches compete; pairwise judging until a winner (comparative > absolute).        | taste-based decisions (naming, design direction)                  |
+| **Loop-until-done**          | Keep spawning until a stop condition (no new findings / no errors), not a fixed count. | `/aep-autopilot` tick loop is the long-lived cousin               |
 
 These compose: a thorough review is _fan-out → adversarial verify → loop-until-dry_.
 
@@ -120,13 +120,13 @@ for every task.
 
 ## How This Fits AEP (touchpoints)
 
-| AEP touchpoint                                          | Sub-pattern it uses               | Relationship                                                                                                                                                     |
-| ------------------------------------------------------- | --------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [`/aep-executor`](../executor/SKILL.md) `workflow` mode | fan-out / pipeline                | Runs one dispatched build wave as a Workflow script — the **narrow** use. This skill is the **general** catalog and the "should I even use a workflow" judgment. |
-| [`/aep-gen-eval`](../gen-eval/SKILL.md)                 | adversarial verification          | Generator/evaluator separation is the canonical instance; workflows generalize it to N independent verifiers/refuters per finding.                               |
-| `/aep-validate` / deep verification                     | fan-out + adversarial verify      | Extract every factual / spec claim, spawn one subagent to check each against the codebase.                                                                       |
-| `/aep-dispatch`                                         | classify-and-route, model routing | A classifier picks story type or model tier before handoff.                                                                                                      |
-| [`/aep-autopilot`](../autopilot/SKILL.md)               | loop-until-done                   | The tick loop is the long-lived, OS-driven cousin of an in-workflow loop-until-dry.                                                                              |
+| AEP touchpoint                                          | Sub-pattern it uses                | Relationship                                                                                                                                                                                                                                                    |
+| ------------------------------------------------------- | ---------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [`/aep-executor`](../executor/SKILL.md) `workflow` mode | fan-out / pipeline                 | Runs one dispatched build wave as a Workflow script — the **narrow** use. This skill is the **general** catalog and the "should I even use a workflow" judgment.                                                                                                |
+| [`/aep-gen-eval`](../gen-eval/SKILL.md)                 | adversarial verification           | Generator/evaluator separation is the canonical instance; workflows generalize it to N independent verifiers/refuters per finding.                                                                                                                              |
+| `/aep-validate`                                         | gen/eval today; fan-out as upgrade | Validate runs a **fixed** Generator/Evaluator(/Protocol Checker) trio and checks claims **inside** the evaluator. When there are many independent claims, a workflow upgrades that to **one verifier per claim** — a generalization validate does not do today. |
+| `/aep-dispatch`                                         | classify-and-route (score-based)   | Dispatch routes by `readiness_score` and offers the "…with workflow" batch opt-in. A classifier agent / model-tier routing is the **workflow** generalization, not what dispatch does today.                                                                    |
+| [`/aep-autopilot`](../autopilot/SKILL.md)               | loop-until-done                    | The tick loop is the long-lived, OS-driven cousin of an in-workflow loop-until-dry.                                                                                                                                                                             |
 
 ### Cross-skill reference path
 

--- a/skills/patterns/workflow/SKILL.md
+++ b/skills/patterns/workflow/SKILL.md
@@ -1,0 +1,187 @@
+---
+name: aep-workflow
+description: |-
+  Reusable pattern for authoring a dynamic workflow — a custom multi-agent harness Claude writes on the fly for one task, run as a Claude Code Workflow (a deterministic JS script that spawns and coordinates context-isolated subagents). This is a utility skill — it provides the sub-pattern catalog (classify-and-route, fan-out-and-synthesize, adversarial verification, generate-and-filter, tournament, loop-until-done) and the "when to reach for a workflow" judgment used by /aep-dispatch, /aep-validate, /aep-gen-eval, and /aep-executor. Use directly when a task is large, uncertain, needs adversarial verification, or runs at scale and the default single-context harness would be lazy, biased, or drift off-goal. Triggers on "dynamic workflow", "ultracode", "write a harness", "harness for this task", "fan out agents", "orchestrate subagents", "tournament", "loop until done", "adversarial verify", "panel of agents". NOT for capturing process feedback — that is /aep-workflow-feedback.
+---
+
+# Dynamic Workflow Pattern
+
+A reusable pattern for **building a custom harness for a single task**. Instead of
+running the task in the one default coding harness, Claude writes a small
+deterministic JavaScript program — a **Claude Code Workflow** — that spawns and
+coordinates subagents, each with its own clean context window, tuned to the task
+at hand.
+
+> "Claude can now write its own harness on the fly, custom-built for the task at
+> hand. While the default Claude Code harness is built for coding, … Claude is now
+> intelligent enough to write a custom harness tailor-made for your use case."
+> — Thariq Shihipar & Sid Bidasaria, Anthropic, ["A harness for every task:
+> dynamic workflows in Claude Code"](https://claude.com/blog/a-harness-for-every-task-dynamic-workflows-in-claude-code)
+
+> **Not `/aep-workflow-feedback`.** That skill captures lessons about the AEP
+> _process_. This skill is about authoring a multi-agent _orchestration script_ for
+> a task. Different jobs, similar prefix.
+
+**This skill is both a utility library and a standalone skill:**
+
+- **As a library:** other skills read `references/pattern-catalog.md` to pick the
+  right sub-pattern and shape its script.
+- **As a standalone skill:** invoke directly to decide whether a task warrants a
+  workflow and to author one.
+
+---
+
+## Why This Pattern Earns Its Place
+
+AEP's third design principle: _every harness component earns its place — each
+exists because of a specific failure mode._ Dynamic workflows are a structural fix
+for three failure modes that appear when a complex task runs inside one context
+window:
+
+| Failure mode               | What it looks like                                                                                                           | How a workflow prevents it                                                                                                                   |
+| -------------------------- | ---------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Agentic laziness**       | Stops after partial progress and declares done (e.g. 35 of 50 security-review items).                                        | Fan-out gives each item its own agent; a `loop-until-done` stop condition replaces a fixed pass count.                                       |
+| **Self-preferential bias** | Praises / passes its own work when asked to verify it against a rubric.                                                      | A _separate_ verifier agent (no authorship attachment) judges each output — the generalized form of [`/aep-gen-eval`](../gen-eval/SKILL.md). |
+| **Goal drift**             | Fidelity to the original objective decays across many turns, especially after compaction; "don't do X" constraints get lost. | Each subagent gets a short, focused goal in a fresh context, so the objective never has to survive a long lossy history.                     |
+
+The mechanism in every case is the same: **isolated context windows + focused
+goals + a deterministic orchestrator** instead of one long, drifting transcript.
+
+---
+
+## The Sub-Pattern Catalog (summary)
+
+Pick the shape that matches the task. Full intent, the Workflow primitive to use
+(`parallel` barrier vs `pipeline` no-barrier vs loop), AEP examples, and skeletons
+are in [`references/pattern-catalog.md`](references/pattern-catalog.md).
+
+| Sub-pattern                  | One-liner                                                                              | AEP instance                                                     |
+| ---------------------------- | -------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
+| **Classify-and-route**       | A classifier agent decides the task type / model tier, then routes.                    | `/aep-dispatch` story-type routing, model routing                |
+| **Fan-out-and-synthesize**   | Split into many small steps → one agent each → a barrier merges results.               | `/aep-executor` `workflow` mode (one agent per story)            |
+| **Adversarial verification** | For each output, a separate agent tries to refute it against a rubric.                 | `/aep-gen-eval` (generator/evaluator) generalized to N verifiers |
+| **Generate-and-filter**      | Generate many candidates → dedupe → keep only rubric-passing ones.                     | naming / design option generation                                |
+| **Tournament**               | N approaches compete; pairwise judging until a winner (comparative > absolute).        | taste-based decisions (naming, design direction)                 |
+| **Loop-until-done**          | Keep spawning until a stop condition (no new findings / no errors), not a fixed count. | `/aep-autopilot` tick loop is the long-lived cousin              |
+
+These compose: a thorough review is _fan-out → adversarial verify → loop-until-dry_.
+
+---
+
+## When to Use a Workflow — and When NOT To
+
+Workflows are powerful but **cost significantly more tokens**. They are not needed
+for every task.
+
+**Reach for a workflow when:**
+
+- The work is **large or unbounded** (sort 1000+ rows, audit every claim, refactor
+  every callsite) — quality degrades if crammed into one prompt.
+- The output **must be verified** by something other than its author (security
+  review, fact-check, eval).
+- The task is **taste-based** and benefits from competing attempts (naming,
+  design direction).
+- You want to **route** different inputs to different handling or model tiers.
+
+**Do NOT reach for a workflow when:**
+
+- It's an ordinary coding task that fits one context. _Most traditional coding
+  tasks do not need a panel of 5 reviewers._ Ask: **does this really need more
+  compute?** If not, just do it.
+- A single `/aep-gen-eval` loop already covers the verification need.
+
+> Rule of thumb from the article: _"use workflows creatively to push Claude Code in
+> ways you haven't previously"_ — not as a default wrapper around routine work.
+
+---
+
+## How to Invoke
+
+1. **Just ask.** "Set up a workflow to…" / "Use a workflow to verify every claim…".
+2. **`ultracode` keyword.** Including `ultracode` forces Claude Code to author a
+   workflow for the request.
+3. **Within AEP.** "…with workflow" routes a dispatched build wave through
+   [`/aep-executor`](../executor/SKILL.md)'s `workflow` backend mode (one agent per
+   locked story, hub-and-spoke gating). See
+   [`../executor/references/backends.md`](../executor/references/backends.md) → _Mode: workflow_.
+
+**Pair with other tools:**
+
+- **`/loop`** — run a repeatable workflow (triage, research, verification) on an
+  interval.
+- **`/goal`** — set a hard completion requirement so the workflow can't quit early
+  (counters laziness).
+- **Token budgets** — prompt with a budget ("use 10k tokens") to cap spend.
+- **Save & share** — press `s` in the workflow menu to save to
+  `~/.claude/workflows`, or distribute via a skill. Treat a saved workflow as a
+  **template**, not a script to run verbatim.
+
+---
+
+## How This Fits AEP (touchpoints)
+
+| AEP touchpoint                                          | Sub-pattern it uses               | Relationship                                                                                                                                                     |
+| ------------------------------------------------------- | --------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [`/aep-executor`](../executor/SKILL.md) `workflow` mode | fan-out / pipeline                | Runs one dispatched build wave as a Workflow script — the **narrow** use. This skill is the **general** catalog and the "should I even use a workflow" judgment. |
+| [`/aep-gen-eval`](../gen-eval/SKILL.md)                 | adversarial verification          | Generator/evaluator separation is the canonical instance; workflows generalize it to N independent verifiers/refuters per finding.                               |
+| `/aep-validate` / deep verification                     | fan-out + adversarial verify      | Extract every factual / spec claim, spawn one subagent to check each against the codebase.                                                                       |
+| `/aep-dispatch`                                         | classify-and-route, model routing | A classifier picks story type or model tier before handoff.                                                                                                      |
+| [`/aep-autopilot`](../autopilot/SKILL.md)               | loop-until-done                   | The tick loop is the long-lived, OS-driven cousin of an in-workflow loop-until-dry.                                                                              |
+
+### Cross-skill reference path
+
+After sync with the `aep-` prefix, the catalog is at:
+
+```
+.claude/skills/aep-workflow/references/pattern-catalog.md
+```
+
+---
+
+## Standalone Usage
+
+1. **Decide if it's worth it.** Apply the "when to use / when NOT" test above. If
+   one context window suffices, stop here and just do the task.
+2. **Pick a sub-pattern** from the catalog (or compose several).
+3. **Choose the primitive:** `parallel` (barrier — you need all results together,
+   e.g. before a dedupe/synthesize), `pipeline` (no barrier — each item flows
+   through stages independently, the default), or a loop (unknown amount of work).
+4. **Add verification** — a separate agent per finding when correctness matters;
+   default verifiers toward refuting, not rubber-stamping.
+5. **Set guardrails** — per-agent model tier, worktree isolation for parallel file
+   edits, a token budget, and (for triage of untrusted content) **quarantine**:
+   agents that read untrusted public content must not take high-privilege actions.
+6. **Author or ask for the script**, then run it.
+
+Read [`references/pattern-catalog.md`](references/pattern-catalog.md) for skeletons.
+
+---
+
+## Design Decisions
+
+**Why a pattern, not just the executor mode.** `/aep-executor` already has a
+`workflow` backend — but it is narrow: run one dispatched _build_ wave as a
+fan-out. The article's idea is broader (verification, tournaments, research,
+triage, evals, sorting at scale) and the most valuable judgment is _when a task
+warrants a workflow at all_. That judgment belongs in a first-class pattern, not
+buried in one executor mode.
+
+**Why it sits next to gen-eval, not inside it.** Generator/evaluator is _one_
+sub-pattern (adversarial verification with N=1 evaluator). `/aep-gen-eval` stays
+the canonical, reusable implementation; this skill points to it rather than
+re-specifying scoring. Likewise `/aep-autopilot` owns the long-lived loop; this
+skill only describes loop-until-done in the short-lived workflow sense.
+
+**Why "when NOT to" is load-bearing.** Workflows multiply token cost. Without an
+explicit guardrail, the pattern degrades into a reflex wrapper around routine
+coding — exactly what the article warns against.
+
+---
+
+## Next Step
+
+After deciding on / authoring a workflow, control returns to the calling context:
+
+- Dispatched build wave → [`/aep-executor`](../executor/SKILL.md) `workflow` mode runs it.
+- Verification / eval of an artifact → fold results back into `/aep-validate` or `/aep-gen-eval`.
+- Standalone research / triage → present the synthesized result; pair with `/loop` if recurring.

--- a/skills/patterns/workflow/references/pattern-catalog.md
+++ b/skills/patterns/workflow/references/pattern-catalog.md
@@ -1,0 +1,233 @@
+# Dynamic Workflow — Sub-Pattern Catalog
+
+Detailed reference for the six dynamic-workflow sub-patterns. Each entry gives the
+**intent**, the **Workflow primitive** to use, an **AEP example**, and a **skeleton**.
+Read [`../SKILL.md`](../SKILL.md) first for the "should I use a workflow at all"
+judgment and the failure modes these patterns counter.
+
+## Primitives (recap)
+
+The Claude Code Workflow tool exposes a few orchestration hooks inside the script:
+
+- `agent(prompt, {schema, label, phase, model, isolation})` — spawn one
+  context-isolated subagent; with a `schema` it returns validated structured output.
+- `parallel(thunks)` — **barrier**: run all, wait for all, return the array. Use
+  only when a later step genuinely needs _every_ prior result at once (dedupe,
+  merge, early-exit on zero).
+- `pipeline(items, stage1, stage2, …)` — **no barrier**: each item flows through
+  all stages independently; item A can be in stage 3 while item B is still in stage
+  1. **This is the default for multi-stage work.**
+- `phase(title)` / `log(msg)` — progress grouping and narration.
+- `budget` — the turn's token target; loop until `budget.remaining()` is low.
+
+Rule: prefer `pipeline`. Reach for a `parallel` barrier only when stage N needs
+cross-item context from _all_ of stage N−1.
+
+---
+
+## 1. Classify-and-route
+
+**Intent.** Decide the _type_ of a task (or output) and send it to the right
+handler or model tier. Either classify up front and dispatch, or classify at the
+end to shape the final result.
+
+**Primitive.** A single classifier `agent()` whose structured result drives a
+branch / model choice; often the first stage of a `pipeline`.
+
+**AEP example.** `/aep-dispatch` deciding story type, or a model-routing classifier
+that sends simple stories to a cheaper tier and hard ones to Opus.
+
+```js
+const klass = await agent(`Classify this task: ${task}. Return {type, complexity}.`, {
+  schema: {
+    type: "object",
+    properties: { type: { type: "string" }, complexity: { enum: ["low", "high"] } },
+    required: ["type", "complexity"],
+  },
+});
+const model = klass.complexity === "high" ? "opus" : "sonnet";
+const result = await agent(handlerPromptFor(klass.type), { model });
+```
+
+---
+
+## 2. Fan-out-and-synthesize
+
+**Intent.** Split a big task into many small, independent steps; run one agent per
+step; then **synthesize** the structured outputs into one result. Best when there
+are many small steps that each benefit from a clean context.
+
+**Primitive.** `parallel` for the fan-out **when** the synthesize step needs all
+results together (it is a barrier — it waits for every fan-out agent, then merges).
+If each item can be reduced independently, use `pipeline` instead.
+
+**AEP example.** `/aep-executor`'s `workflow` mode: one build agent per locked
+story in a dispatched wave, results collected for the main agent.
+
+```js
+const parts = await parallel(
+  steps.map((s) => () => agent(`Do step: ${s.goal}`, { schema: PART, phase: "Fan-out" })),
+);
+const merged = await agent(
+  `Synthesize these parts into one result: ${JSON.stringify(parts.filter(Boolean))}`,
+  { schema: RESULT, phase: "Synthesize" },
+);
+```
+
+---
+
+## 3. Adversarial verification
+
+**Intent.** For each produced output, run a **separate** agent that tries to
+_refute_ it against a rubric or criteria — never let the author grade its own work.
+Counters self-preferential bias directly.
+
+**Primitive.** `pipeline`: stage 1 produces, stage 2 verifies. For higher
+confidence, fan a small panel of independent refuters per finding and take a
+majority.
+
+**AEP example.** The generalized form of [`/aep-gen-eval`](../../gen-eval/SKILL.md)
+(generator/evaluator) — reuse its scoring framework and findings format.
+
+```js
+const checked = await pipeline(
+  findings,
+  (f) =>
+    agent(
+      `Finding: ${f.claim}. Try to REFUTE it against the rubric. Default to refuted=true if uncertain.`,
+      { schema: VERDICT, phase: "Verify" },
+    ),
+  (v, f) => ({ ...f, real: v && !v.refuted }),
+);
+const confirmed = checked.filter((x) => x.real);
+```
+
+---
+
+## 4. Generate-and-filter
+
+**Intent.** Generate many candidate ideas on a topic, then **filter** them by a
+rubric or by verification, dedupe duplicates, and return only the highest-quality,
+tested ones.
+
+**Primitive.** `parallel` to generate, plain code to dedupe, then `parallel` (or a
+verify stage) to filter. The dedupe is a genuine barrier — it needs all candidates.
+
+**AEP example.** Brainstorming naming or design options before a calibration gate.
+
+```js
+const raw = (
+  await parallel(
+    angles.map((a) => () => agent(`Generate candidates from the ${a} angle.`, { schema: IDEAS })),
+  )
+)
+  .filter(Boolean)
+  .flatMap((r) => r.ideas);
+const unique = dedupe(raw); // plain JS, not an agent
+const kept = (
+  await parallel(
+    unique.map(
+      (i) => () =>
+        agent(`Score "${i}" against the rubric; keep only if it passes.`, { schema: SCORE }),
+    ),
+  )
+)
+  .filter(Boolean)
+  .filter((s) => s.passes);
+```
+
+---
+
+## 5. Tournament
+
+**Intent.** When quality is subjective, have agents **compete**. Spawn N agents
+that each attempt the same task with a _different_ approach, then judge results in
+a **pairwise** fashion until a winner emerges. Comparative judgment is more
+reliable than absolute scoring.
+
+**Primitive.** `parallel` to produce the bracket entrants; then pairwise judge
+agents (a reduction, often a loop) until one winner remains.
+
+**AEP example.** Taste-based decisions — naming, design direction — feeding a
+`/aep-calibrate` gate with the top candidates.
+
+```js
+let bracket = await parallel(
+  approaches.map((a) => () => agent(`Attempt the task using approach: ${a}.`, { schema: ENTRY })),
+);
+bracket = bracket.filter(Boolean);
+while (bracket.length > 1) {
+  const next = [];
+  for (let i = 0; i < bracket.length; i += 2) {
+    if (!bracket[i + 1]) {
+      next.push(bracket[i]);
+      continue;
+    }
+    const win = await agent(
+      `Pick the better of A vs B for the goal.\nA:${JSON.stringify(bracket[i])}\nB:${JSON.stringify(bracket[i + 1])}`,
+      {
+        schema: {
+          type: "object",
+          properties: { winner: { enum: ["A", "B"] } },
+          required: ["winner"],
+        },
+      },
+    );
+    next.push(win.winner === "A" ? bracket[i] : bracket[i + 1]);
+  }
+  bracket = next;
+}
+const champion = bracket[0];
+```
+
+---
+
+## 6. Loop-until-done
+
+**Intent.** For tasks with an **unknown** amount of work, keep spawning agents
+until a _stop condition_ is met (no new findings, no more errors in the logs)
+rather than a fixed number of passes. Counters laziness and premature "done".
+
+**Primitive.** A `while` loop around `agent()`/`parallel()`, with a "dry rounds"
+counter and a `seen` set so re-discovered items don't reset the loop.
+
+**AEP example.** The short-lived cousin of `/aep-autopilot`'s tick loop —
+e.g. reproduce a 1-in-50 flaky test, or mine a log until no new root causes appear.
+
+```js
+const seen = new Set();
+let dry = 0;
+while (dry < 2 && (!budget.total || budget.remaining() > 50_000)) {
+  const found = (
+    await agent("Find the next distinct issue; return [] if none.", { schema: ISSUES })
+  ).issues;
+  const fresh = found.filter((i) => !seen.has(key(i)));
+  if (!fresh.length) {
+    dry++;
+    continue;
+  }
+  dry = 0;
+  fresh.forEach((i) => seen.add(key(i)));
+  log(`${seen.size} distinct issues so far`);
+}
+```
+
+---
+
+## Architectural levers
+
+Independent of which sub-pattern you pick, a workflow can tune:
+
+- **Per-agent model tier.** Cheap classifier / mechanical stages on a small model;
+  hard judging or synthesis on the strongest. Pass `model` per `agent()`.
+- **Worktree isolation.** Use `isolation: 'worktree'` only when agents mutate files
+  in parallel and would otherwise conflict (it has real setup cost). In AEP, prefer
+  AEP-created `.feature-workspaces/<ws>` worktrees so `monitor()` / `/aep-wrap` paths
+  stay standard — see `../../executor/references/backends.md`.
+- **Quarantine.** In triage workflows, agents that read **untrusted public content**
+  must be barred from high-privilege actions — keep read-untrusted and act-with-
+  privilege in separate agents.
+- **Token budgets.** Scale fleet size or loop depth to `budget`; a hard ceiling
+  prevents runaway spend.
+- **Resumability.** If a workflow is interrupted, resuming the session lets it pick
+  up where it left off; completed agents return from cache.


### PR DESCRIPTION
## What & why

Extracts the idea from Anthropic's [*"A harness for every task: dynamic workflows in Claude Code"*](https://claude.com/blog/a-harness-for-every-task-dynamic-workflows-in-claude-code) (Thariq Shihipar & Sid Bidasaria) into a first-class AEP pattern.

A **dynamic workflow** is a harness Claude writes itself for one task — a deterministic JS script that orchestrates context-isolated subagents. The article frames it as a structural fix for three failure modes of long single-context work, all of which AEP already cares about:

- **Agentic laziness** — stops after partial progress and declares done (e.g. 35/50 review items).
- **Self-preferential bias** — passes its own work when asked to verify it (AEP already counters this with `/aep-gen-eval`).
- **Goal drift** — fidelity to the objective decays across many turns, especially after compaction.

AEP previously treated this only narrowly (the `aep-executor` `workflow` backend runs one build wave as a Workflow script). This PR adds the broader pattern + the "when (not) to reach for a workflow" judgment.

## New skill: `/aep-workflow` (patterns group)

Dual library + standalone skill (same shape as `/aep-gen-eval`). Carries a sub-pattern catalog and **cross-links** existing patterns rather than duplicating them:

| Sub-pattern | AEP instance |
| --- | --- |
| classify-and-route / model routing | `/aep-dispatch` |
| fan-out-and-synthesize | `/aep-executor` `workflow` mode |
| adversarial verification | `/aep-gen-eval` (generalized to N verifiers) |
| generate-and-filter | option generation |
| tournament | taste-based decisions |
| loop-until-done | `/aep-autopilot` (long-lived cousin) |

## Changes

**Added**
- `skills/patterns/workflow/SKILL.md` + `references/pattern-catalog.md`
- `docs/research/dynamic-workflows.md` (source + rationale)

**Wired in (full)**
- `marketplace.json`: register skill; **version bump `2.1.0` → `2.2.0`** (new skill = minor)
- `CHANGELOG.md`: `[2.2.0]` entry
- `README.md`: both skill tables + Documentation link
- `docs/orientation.md` + `docs/skills-quick-reference.md`: matrix rows, decision tree (count `19 → 20`)
- `docs/glossary.md`: "Dynamic Workflow" term + Harness cross-link
- Cross-links from `aep-executor` (SKILL + backends) and `aep-gen-eval`

## Notes
- `/aep-workflow` is kept trigger-disjoint from the existing `/aep-workflow-feedback`.
- **Pre-existing gap (not touched here):** `docs/orientation.md` and `docs/skills-quick-reference.md` already omit `/aep-executor` from their skill tables, so their counts trail `marketplace.json` (21) by one. Can reconcile separately.

## Verification
- `marketplace.json` parses; `patterns` plugin lists `workflow`
- `bash scripts/build-skills.sh --check` → in sync (patterns/ not processed by the build)
- all relative links resolve; frontmatter parses (`name: aep-workflow`)
- pre-commit (oxlint/oxfmt) clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0122XmBd1Jdbk5joZZsDtuph