### PR TITLE
docs(aep): deterministic-orchestration decision doc (typed gates for mechanical steps)

### DIFF
--- a/docs/decisions/deterministic-orchestration.md
+++ b/docs/decisions/deterministic-orchestration.md
@@ -2,7 +2,7 @@
 
 An empirical law from running AEP's orchestration loop at scale: **every orchestration step that lives only as prose an LLM must recall eventually gets skipped; no step behind a typed gate ever was.** This document upstreams what to do about it in a methodology repo that ships prose skills and no runtime: name the mechanical/judgment boundary in AEP's own lifecycle skills, teach downstream projects to move their mechanical steps behind typed gates, and fix the specific prose invariants (stale worktree base, hand-recalled dispatch briefs) that the evidence showed failing. Companion to [build-convergence-pipeline.md](build-convergence-pipeline.md), whose gather-before-archive ordering invariant is one instance of the class this document generalizes.
 
-> **Status:** Proposal (not yet implemented). This document records the design precisely so the implementation PR (target: v2.8.0) can be made and reviewed against it. It changes how AEP works, so it lives in `decisions/` per the [docs routing guide](../README.md).
+> **Status:** Proposal (not yet implemented). This document records the design precisely so the implementation PR (target: v2.7.0, shared with build-convergence-pipeline.md) can be made and reviewed against it. It changes how AEP works, so it lives in `decisions/` per the [docs routing guide](../README.md).
 
 > **Sourcing note:** Sourced from SIBYL layers 15–21 (`SIBYL/docs/AEP-improvement-suggestion/2026-07-10-deterministic-orchestration-upstream-notes.md` and the full reflection in `SIBYL/docs/design/2026-07-10-deterministic-orchestration.md`: phenomena inventory, three-way design comparison, the L21 verb slice). SIBYL's concrete machinery — its `story dispatch` / `story land` TypeScript CLI verbs and control-plane splice transactions — stays downstream; what upstreams here is the boundary, the gate pattern, and the prose-invariant fixes.
 
@@ -77,7 +77,7 @@ Anything an LLM re-types drifts. The deterministic layer — not the orchestrato
 
 ---
 
-## What upstream changes now (v2.8.0) vs future
+## What upstream changes now (v2.7.0) vs future
 
 **Now — a pattern reference plus prose-invariant fixes; no new commands, no runtime:**
 
@@ -88,7 +88,7 @@ Anything an LLM re-types drifts. The deterministic layer — not the orchestrato
 5. **`skills/agentic-development-workflow/wrap/SKILL.md`** — Guardrails: annotate the step chain as an ordering invariant with its world-derived postcondition per step (one line each, per the probe catalog).
 6. **`skills/patterns/autopilot/SKILL.md`** (Guardrails `:679-694`) + **`references/tick-protocol.md`** — annotate wrap-before-dispatch and one-launch-per-tick (`tick-protocol.md:456`) as named ordering invariants; recommend downstream typed gates for tick CHECK preconditions.
 7. **`docs/glossary.md`** — new entries: **Typed Gate (Typed Verb)**, **Named Refusal**, **World-Derived Resumability**, **Machine-Assembled Dispatch Brief**, **Mechanical/Judgment Split**.
-8. `CHANGELOG.md` `[2.8.0]`; `.claude-plugin/marketplace.json` + `package.json` → `2.8.0`. No `_shared/` files change.
+8. `CHANGELOG.md` `[2.7.0]` (one release shared with the convergence pipeline); `.claude-plugin/marketplace.json` + `package.json` → `2.7.0`. No `_shared/` files change.
 
 **Future — explicit non-goals of this proposal, recorded as horizon:**
 
@@ -115,11 +115,11 @@ All changes are prose-additive — annotations, warnings, and one new reference 
 | **P0 — this decision doc** | Record the law, the split, the pattern                                        | No        |
 | **P1 — pattern reference** | Ship `autopilot/references/deterministic-orchestration.md`                    | No        |
 | **P2 — prose invariants**  | Stale-base + brief-assembly + ordering-invariant edits across the four skills | No        |
-| **P3 — glossary + bump**   | Taxonomy entries; v2.8.0                                                      | No        |
+| **P3 — glossary + bump**   | Taxonomy entries; v2.7.0 (shared release)                                     | No        |
 
 **Exact change sites:** the numbered list under "What upstream changes now" is the implementation PR's review contract.
 
-**Propagation discipline:** this proposal introduces net-new taxonomy — _typed gate_, _named refusal_, _world-derived resumability_, _machine-assembled dispatch brief_, _mechanical/judgment split_ (none of these terms exist in the repo today). Every skill that names one must say it identically and the glossary must define it; audit with `grep -rn "typed gate\|named refusal\|world-derived" skills/ docs/` after implementation. No `_shared/` enum is touched, so no `build-skills.sh` diff is expected — `skills:check` must come back clean. Downstream consumers go live only after the v2.8.0 tag is cut and each consumer re-pins via the skills CLI.
+**Propagation discipline:** this proposal introduces net-new taxonomy — _typed gate_, _named refusal_, _world-derived resumability_, _machine-assembled dispatch brief_, _mechanical/judgment split_ (none of these terms exist in the repo today). Every skill that names one must say it identically and the glossary must define it; audit with `grep -rn "typed gate\|named refusal\|world-derived" skills/ docs/` after implementation. No `_shared/` enum is touched, so no `build-skills.sh` diff is expected — `skills:check` must come back clean. Downstream consumers go live only after the v2.7.0 tag is cut and each consumer re-pins via the skills CLI.
 
 ---
 

--- a/docs/decisions/deterministic-orchestration.md
+++ b/docs/decisions/deterministic-orchestration.md
@@ -1,0 +1,151 @@
+# Deterministic Orchestration: Mechanical Steps Behind Typed Gates
+
+An empirical law from running AEP's orchestration loop at scale: **every orchestration step that lives only as prose an LLM must recall eventually gets skipped; no step behind a typed gate ever was.** This document upstreams what to do about it in a methodology repo that ships prose skills and no runtime: name the mechanical/judgment boundary in AEP's own lifecycle skills, teach downstream projects to move their mechanical steps behind typed gates, and fix the specific prose invariants (stale worktree base, hand-recalled dispatch briefs) that the evidence showed failing. Companion to [build-convergence-pipeline.md](build-convergence-pipeline.md), whose gather-before-archive ordering invariant is one instance of the class this document generalizes.
+
+> **Status:** Proposal (not yet implemented). This document records the design precisely so the implementation PR (target: v2.8.0) can be made and reviewed against it. It changes how AEP works, so it lives in `decisions/` per the [docs routing guide](../README.md).
+
+> **Sourcing note:** Sourced from SIBYL layers 15–21 (`SIBYL/docs/AEP-improvement-suggestion/2026-07-10-deterministic-orchestration-upstream-notes.md` and the full reflection in `SIBYL/docs/design/2026-07-10-deterministic-orchestration.md`: phenomena inventory, three-way design comparison, the L21 verb slice). SIBYL's concrete machinery — its `story dispatch` / `story land` TypeScript CLI verbs and control-plane splice transactions — stays downstream; what upstreams here is the boundary, the gate pattern, and the prose-invariant fixes.
+
+---
+
+## The empirical law (diagnosis)
+
+Twenty-one layers of a downstream product were built by an LLM orchestrator running the AEP loop: dispatch a story into an isolated worktree agent, evaluate, merge, wrap, archive. Under that load the failures sorted cleanly by mechanism:
+
+**What drifted (prose the LLM had to recall):**
+
+- Forgotten OpenSpec change dirs; forgotten `isolation: "worktree"` (two agents intermixed in the primary checkout); a whole layer built with **zero** pre-teardown signal gathering. Twice the human owner had to interrupt to restore the prescribed process — the exact failure mode the methodology exists to remove.
+- Hand-edited control-plane YAML corrupted state whenever validation was not chained before the commit (quote-eating heredocs, stray characters committed one commit before validation ran).
+- A subagent's returned "result" contained prompt-injection payloads (fake `<system-reminder>` blocks) that a prose rule alone had to catch — three times.
+
+**What never drifted (typed gates):** schema-validated submits, CLI verbs that refuse with named errors, validate-then-write transactions, exit-code test gates. Across six layers of heavy use, **zero** regressions on any step owned by a typed gate.
+
+**The host-level hazard, named:** agents spawned with the host's `isolation: "worktree"` (e.g. Claude Code's Workflow/Agent tool) base their worktrees on a **stale `origin/main`**, not the local integration-branch HEAD. In a control-on-main workflow the local tip is almost always ahead — it carries the dispatch-lock commit itself — so every spawned worker starts from a base that predates the very lock that dispatched it, and the drift only surfaces at merge time. Every one of one layer's eight dispatches needed a hand-run correction inside the worker (`git checkout -B story/<id> <local-main-sha>`); setting `worktree.baseRef=head` did not change the behavior. AEP already half-knows this class of bug: `/aep-launch` ABORTs when the dispatch commit is unpushed (`launch/SKILL.md:61`) because workspace branches would base off a `$BASE` missing it, and `patterns/executor/references/backends.md:462-467` prefers AEP-created worktrees over host-managed isolation — but neither names the stale-base failure nor mandates a machine-assembled correction.
+
+---
+
+## The mechanical / judgment split
+
+**Mechanical** = anything with a deterministic WHEN and SHAPE: preconditions, state flips, ordering invariants, prompt assembly. **Judgment** = implementation, scoring, grouping, prose, diagnosis. The law says: mechanical steps drift when left to LLM recall and hold when owned by mechanism; judgment steps are what LLMs are _for_.
+
+Applied to AEP's own lifecycle skills:
+
+| Lifecycle step                                                                                                                                                     | Class                                 | Today                               |
+| ------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------- | ----------------------------------- |
+| Autopilot tick ① read state, ③ wrap completed, ⑥ dispatch gating, ⑦ write state; wrap-before-dispatch; one-wrap/one-launch-per-tick (`autopilot/SKILL.md:690-691`) | mechanical                            | prose checklist                     |
+| Autopilot tick ④ quality assessment, ⑤ stuck diagnosis                                                                                                             | judgment (with mechanical thresholds) | prose — correctly so                |
+| Dispatch sync / cascade / **dispatch lock** (commit BEFORE workspace, `dispatch/SKILL.md:364-381`) / WIP math (`:352-360`) / brief assembly                        | mechanical                            | prose checklist                     |
+| Dispatch scoring rationale, story selection explanation                                                                                                            | judgment                              | prose — correctly so                |
+| Wrap step chain: gather → archive → commit → status flip → lessons → teardown (`wrap/SKILL.md:57-173`)                                                             | mechanical (pure ordering invariants) | prose checklist + guardrail bullets |
+| Build implementation, gen-eval content, recovery-ladder rung choice                                                                                                | judgment                              | prose — correctly so                |
+
+The judgment rows are healthy. Every incident in the diagnosis maps to a mechanical row.
+
+---
+
+## The typed-gate pattern (what downstream projects build)
+
+AEP ships prose, not a runtime — so the _general_ fix is a pattern downstream projects implement in their own tooling (a CLI verb, a script, a hook), plus prose-invariant fixes upstream can make directly (next section). The pattern has three pillars, each with a proven shape:
+
+### 1. Named refusals
+
+A gate that fails must **refuse with a named tag**, not a prose suggestion: `REFUSING [openspec-proposal-exists]: openspec/changes/<id>/proposal.md does not exist`, exit codes `0` success / `1` refusal / `2` bad invocation. Collect **every** unmet precondition into one refusal (never first-failure-only). A refusal is a _success mode of the gate_ — the orchestrating LLM reads the tag and fixes the named thing; it cannot rationalize past an exit code the way it can past a checklist bullet.
+
+### 2. World-derived resumability
+
+Derive step completion from **observable world state** (git, filesystem), never from a state file:
+
+| Postcondition  | Probe                                                                     |
+| -------------- | ------------------------------------------------------------------------- |
+| merged         | `git merge-base --is-ancestor <branch> <base>`                            |
+| gathered       | the execution record exists (pre- or post-archive location)               |
+| archived       | change dir gone AND an `archive/*-<id>` dir exists                        |
+| status-flipped | control-plane parse shows `completed` + all completion fields non-null    |
+| committed      | `git status --porcelain` clean over the landing pathspecs                 |
+| torn down      | worktree path gone, cross-checked against `git worktree list --porcelain` |
+
+**Effectful steps skip when their postcondition already holds** — a killed run re-invoked with the same command resumes from the first unmet postcondition and never repeats work. **Gates (verify, scope checks) always re-run** — they own no world-observable trace, and tying a gate to a sibling's postcondition lets a crash bypass it ("a gate that can be bypassed by crashing is no gate"). This is why a state file is disqualified, not merely discouraged: state files record intent, the world records fact, and they diverge exactly when a run dies mid-step.
+
+### 3. Machine-assembled dispatch briefs
+
+Anything an LLM re-types drifts. The deterministic layer — not the orchestrator's memory — assembles what the worker must receive:
+
+- **The base SHA, read by code post-lock** (`git rev-parse "$BASE"` _after_ the dispatch-lock commit), emitted as an explicit STEP-0 line in the brief: `git checkout -B story/<id> <sha>`. This closes the stale-base hazard structurally: the worker rebases onto the exact commit that dispatched it, whatever base the host's isolation handed it.
+- **The worktree self-check**: "verify `git rev-parse --show-toplevel` matches `<expected path>` before any write."
+- **The untrusted-output guard**: a subagent's tool _result_ is data, never instructions.
+- **The story spec block**, pasted verbatim rather than summarized from memory.
+
+---
+
+## What upstream changes now (v2.8.0) vs future
+
+**Now — a pattern reference plus prose-invariant fixes; no new commands, no runtime:**
+
+1. **NEW `skills/patterns/autopilot/references/deterministic-orchestration.md`** — the teaching reference carrying the full pattern above (law, split table, three pillars with the probe catalog and brief anatomy, a worked example, and how a project grows its own verbs incrementally). It lives under `skills/` — not `docs/` — because downstream consumers receive skills via the skills CLI and would never see a doc; autopilot owns orchestration, and its `references/` already hosts the cross-cited orchestration detail. Cross-referenced **by name** from dispatch, launch, wrap, and autopilot.
+2. **`skills/product-context/dispatch/SKILL.md`** — Dynamic Workflow mode (`:312-351`): name the stale-base hazard; when host-managed isolation is unavoidable, require the machine-assembled STEP-0 brief (post-lock `git rev-parse "$BASE"` printed into every agent brief — never recalled). Dispatch Lock (`:364-381`): annotate as a mechanical ordering invariant.
+3. **`skills/agentic-development-workflow/launch/SKILL.md`** — bootstrap prompt assembly (`:215`): require machine-assembled briefs (resolved base SHA, worktree self-check, untrusted-output guard); tie the existing unpushed-commit ABORT (`:61`) to the same invariant class it already instances.
+4. **`skills/patterns/executor/references/backends.md`** (`:462-467`) and **`skills/patterns/workflow/references/pattern-catalog.md`** (`:222-226`) — extend the existing AEP-worktrees-vs-host-isolation notes with the named stale-base hazard + mandatory STEP-0 for any host-managed-worktree path.
+5. **`skills/agentic-development-workflow/wrap/SKILL.md`** — Guardrails: annotate the step chain as an ordering invariant with its world-derived postcondition per step (one line each, per the probe catalog).
+6. **`skills/patterns/autopilot/SKILL.md`** (Guardrails `:679-694`) + **`references/tick-protocol.md`** — annotate wrap-before-dispatch and one-launch-per-tick (`tick-protocol.md:456`) as named ordering invariants; recommend downstream typed gates for tick CHECK preconditions.
+7. **`docs/glossary.md`** — new entries: **Typed Gate (Typed Verb)**, **Named Refusal**, **World-Derived Resumability**, **Machine-Assembled Dispatch Brief**, **Mechanical/Judgment Split**.
+8. `CHANGELOG.md` `[2.8.0]`; `.claude-plugin/marketplace.json` + `package.json` → `2.8.0`. No `_shared/` files change.
+
+**Future — explicit non-goals of this proposal, recorded as horizon:**
+
+- A **verb-scaffolding skill** (in the mold of `e2e-skill-scaffolding`) that generates typed-verb stubs — dispatch/land skeletons with named refusals and postcondition probes — in a downstream project's own language and control-plane. Sliced only after the pattern reference proves out downstream.
+- Any AEP-shipped runtime or harness. AEP stays prose; the verbs belong to the project.
+
+---
+
+## Forcing functions
+
+| Skill            | New responsibility                                                                                                    |
+| ---------------- | --------------------------------------------------------------------------------------------------------------------- |
+| `/aep-dispatch`  | Stale-base warning + machine-assembled STEP-0 brief for host-managed isolation; dispatch lock annotated as mechanical |
+| `/aep-launch`    | Bootstrap brief must be machine-assembled (base SHA, self-check, untrusted-output guard)                              |
+| `/aep-wrap`      | Step chain annotated with world-derived postconditions                                                                |
+| `/aep-autopilot` | Owns the pattern reference; tick ordering invariants named; recommends downstream typed gates                         |
+
+## Migration
+
+All changes are prose-additive — annotations, warnings, and one new reference file. No step is removed, renumbered, or made to require tooling a project doesn't have; a project that ignores the pattern reference keeps today's behavior.
+
+| Phase                      | Action                                                                        | Breaking? |
+| -------------------------- | ----------------------------------------------------------------------------- | --------- |
+| **P0 — this decision doc** | Record the law, the split, the pattern                                        | No        |
+| **P1 — pattern reference** | Ship `autopilot/references/deterministic-orchestration.md`                    | No        |
+| **P2 — prose invariants**  | Stale-base + brief-assembly + ordering-invariant edits across the four skills | No        |
+| **P3 — glossary + bump**   | Taxonomy entries; v2.8.0                                                      | No        |
+
+**Exact change sites:** the numbered list under "What upstream changes now" is the implementation PR's review contract.
+
+**Propagation discipline:** this proposal introduces net-new taxonomy — _typed gate_, _named refusal_, _world-derived resumability_, _machine-assembled dispatch brief_, _mechanical/judgment split_ (none of these terms exist in the repo today). Every skill that names one must say it identically and the glossary must define it; audit with `grep -rn "typed gate\|named refusal\|world-derived" skills/ docs/` after implementation. No `_shared/` enum is touched, so no `build-skills.sh` diff is expected — `skills:check` must come back clean. Downstream consumers go live only after the v2.8.0 tag is cut and each consumer re-pins via the skills CLI.
+
+---
+
+## Worked example: the landing verb SIBYL built
+
+SIBYL moved the mechanical half of its per-story loop behind two CLI verbs; the landing verb runs eight steps — scope-gate → merge → verify → gather → archive → flip → align → teardown — as a **world-derived resumable step machine**. Each effectful step is guarded by a postcondition from the probe catalog above; a run killed after `merge` and re-invoked skips straight past `merged == true` to `verify` (a gate — always re-runs), and a fully-landed story re-runs as a no-op with exit 0. Every refusal is named (`REFUSING [diff-scope]` lists each out-of-scope file; `HALT [verify-failed]` stops _before_ archive and flip, leaving main on the merge commit). The layer that built the verbs landed its own final story through them — the dogfood contract held. This — not the TypeScript — is the target shape: the eight steps, the probes, and the refusal tags translate to a shell script or a Make target as readily as to a CLI.
+
+The judgment half (implementation, eval scoring, wave grouping, recovery-rung choice) stayed in a versioned skill, which is the other half of the lesson: **the fix is not "less LLM" — it is putting the WHEN and SHAPE in mechanism so the LLM spends its judgment where judgment is wanted.**
+
+---
+
+## Anti-patterns this prevents
+
+- **Prose-recall preconditions.** "Remember to check dependencies before dispatching" _will_ eventually be skipped; a gate that refuses `[dependencies-completed]` will not.
+- **State-file resumability.** A `progress.json` diverges from reality the moment a run dies mid-step; the world cannot.
+- **LLM-re-typed base SHAs** (or paths, or spec blocks). If the orchestrator re-types it, it drifts; the deterministic layer assembles it once, at dispatch time.
+- **Skipping a gate because its region "probably completed".** Gates always re-run; only effectful steps skip on satisfied postconditions.
+- **Treating a refusal as an error to route around.** The named tag _is_ the instruction; fix the named thing and re-run the same command.
+
+---
+
+## References
+
+- `SIBYL/docs/AEP-improvement-suggestion/2026-07-10-deterministic-orchestration-upstream-notes.md` — the originating upstream notes (Finding 1: stale base; Finding 2: prose drift vs typed gates).
+- `SIBYL/docs/design/2026-07-10-deterministic-orchestration.md` — the full evidence base: phenomena inventory (§1), three-way design comparison (§2), determinism boundary (§3), the L21 verb slice (§4).
+- [build-convergence-pipeline.md](build-convergence-pipeline.md) — companion proposal; its gather-before-archive invariant and file-existence distill idempotence are instances of this document's ordering-invariant and world-derived-resumability classes.
+- `skills/agentic-development-workflow/launch/SKILL.md:61` — the existing unpushed-commit ABORT: AEP's one prior acknowledgment of the base-freshness invariant class.
+- `skills/patterns/executor/references/backends.md:462-467` — the existing AEP-worktrees-vs-host-isolation preference this proposal sharpens into a named hazard.
+- Affected skills: `/aep-dispatch`, `/aep-launch`, `/aep-wrap`, `/aep-autopilot`.


### PR DESCRIPTION
## What

Adds `docs/decisions/deterministic-orchestration.md` — a decision doc (Proposal status) upstreaming SIBYL's L15–L21 orchestration findings. **Docs-only: no schema or skill edits, no version bump** (decision-doc-first discipline; implementation lands in the shared v2.7.0 release against this document).

## Why

The empirical law from 21 layers of orchestrated builds: *every orchestration step that lives only as prose an LLM must recall eventually gets skipped; no step behind a typed gate ever was.* Plus a concrete host hazard: `isolation: "worktree"` bases spawned agents on stale `origin/main`, so every worker starts from a base predating the dispatch lock that spawned it. Sources: `SIBYL/docs/AEP-improvement-suggestion/2026-07-10-deterministic-orchestration-upstream-notes.md` + the full design reflection.

## The proposal

- **Name the mechanical/judgment split** across AEP's own lifecycle skills (classification table for autopilot/dispatch/wrap/build steps).
- **The typed-gate pattern** downstream projects build in their own tooling: named refusals (`REFUSING [tag]` + exit codes), world-derived resumability (postconditions from git/filesystem, never state files; gates always re-run), machine-assembled dispatch briefs (post-lock base SHA + STEP-0 rebase line, never LLM-recalled).
- **Upstream scope now (v2.8.0):** a pattern reference at `skills/patterns/autopilot/references/deterministic-orchestration.md` + prose-invariant fixes in dispatch/launch/backends/pattern-catalog/wrap/autopilot + glossary taxonomy. **Future non-goals:** verb-scaffolding skill, any AEP-shipped runtime.

## Notes for review

- Companion to #20 (build-convergence-pipeline); the two docs cross-link — each link resolves once both merge.
- "What upstream changes now" is the review contract for the follow-up v2.7.0 implementation PR (shared with #20).
- `bun run skills:check` green (no skill files touched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DHAxTpTbcTM2dizXweiFCv
