### PR TITLE
docs(aep): verification-economics decision doc (risk-tiered validators + tamper-evident evidence)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -12,6 +12,7 @@ Rules for organizing documentation in this directory.
 | **Lessons**    | `lessons/`    | Date-prefixed observations from downstream project runs                                               | `YYYY-MM-DD-<project>-<context>.md`                             |
 | **Plans**      | `plans/`      | Design plans from `/design` skill                                                                     | `YYYY-MM-DD-<topic>.md`                                         |
 | **Research**   | `research/`   | Exploratory studies, source reviews, and gap analyses before a decision or implementation plan exists | Descriptive slug (`ooux-object-modeling.md`)                    |
+| **Audits**     | `audits/`     | Point-in-time compatibility and implementation evidence for a specific downstream or release          | `YYYY-MM-DD-<scope>.md`                                         |
 
 ## Key Distinctions
 
@@ -27,6 +28,7 @@ These stay at the docs root because they're cross-cutting references:
 
 - `glossary.md` — Ubiquitous language across all skills
 - `skills-quick-reference.md` — Quick lookup for all AEP skills
+- `aep-v3.0.0-migration-guide.md` — Safe downstream re-pin, cutover, canary, and rollback runbook
 
 ## Routing Guide
 
@@ -38,3 +40,4 @@ When adding new documentation, ask:
 4. **"Does this explain an existing AEP pattern?"** → `workflow/`
 5. **"Is this a forward-looking design for a feature?"** → `plans/`
 6. **"Is this still exploratory evidence or gap analysis?"** → `research/`
+7. **"Is this a point-in-time compatibility or implementation check?"** → `audits/`

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,6 +13,7 @@ Rules for organizing documentation in this directory.
 | **Plans**      | `plans/`      | Design plans from `/design` skill                                                                     | `YYYY-MM-DD-<topic>.md`                                         |
 | **Research**   | `research/`   | Exploratory studies, source reviews, and gap analyses before a decision or implementation plan exists | Descriptive slug (`ooux-object-modeling.md`)                    |
 | **Audits**     | `audits/`     | Point-in-time compatibility and implementation evidence for a specific downstream or release          | `YYYY-MM-DD-<scope>.md`                                         |
+| **Articles**   | `article/`    | Self-contained write-ups distilled from decisions/research, written to be shareable outside the repo  | Descriptive slug (`three-mechanisms-….md`)                      |
 
 ## Key Distinctions
 
@@ -41,3 +42,4 @@ When adding new documentation, ask:
 5. **"Is this a forward-looking design for a feature?"** → `plans/`
 6. **"Is this still exploratory evidence or gap analysis?"** → `research/`
 7. **"Is this a point-in-time compatibility or implementation check?"** → `audits/`
+8. **"Is this a self-contained story for readers outside this repo?"** → `article/`

--- a/docs/aep-v3.0.0-migration-guide.md
+++ b/docs/aep-v3.0.0-migration-guide.md
@@ -1,0 +1,593 @@
+# AEP v3.0.0 Downstream Migration Guide
+
+This guide upgrades a downstream repository from an AEP v2.x pin to the exact
+`v3.0.0` release. It is written for repositories that commit installed skills for
+Claude Code and Codex, keep AEP workflow state under `.dev-workflow/`, and may use
+split product context.
+
+The evidence-backed path is v2.5.0 → v3.0.0. Repositories on an earlier v2 release
+must also review the cumulative release notes between their pin and v2.5.0; do not
+assume the Looplia audit covers an older local schema or custom workflow fork.
+
+The migration is a **skill re-pin plus a controlled runtime cutover**. It is not a
+product-context data migration. Do not rewrite stories, layers, calibration files,
+or autopilot state merely to adopt v3.0.0.
+
+For the concrete evidence behind these instructions, see the
+[Looplia v2.5.0 → v3.0.0 compatibility audit](audits/2026-07-15-looplia-v2.5.0-to-v3.0.0-compatibility.md).
+
+## Migration Contract
+
+The safe upgrade sequence is:
+
+1. Reach a terminal lifecycle boundary on the old pin.
+2. Re-pin both agent runtimes in an isolated PR.
+3. Converge the shared skills layout.
+4. Verify that product and runtime data were not changed.
+5. Merge only after deterministic checks pass.
+6. Start fresh agent sessions and run a bounded behavior canary.
+
+The rollback unit is the re-pin PR. Keeping product data out of that PR makes
+rollback mechanical and prevents workflow state from being coupled to skill bytes.
+
+## What Changes in v3.0.0
+
+### Front-tier footprint
+
+Compared directly with v2.5.0, v3.0.0 reduces the front-tier surface while moving
+detail into references:
+
+| Metric            | v2.5.0 | v3.0.0 | Change |
+| ----------------- | -----: | -----: | -----: |
+| Front-tier lines  |  7,816 |  4,873 | -37.7% |
+| Description words |  1,522 |    652 | -57.2% |
+
+This is the primary token-efficiency improvement. The intended behavior is
+progressive disclosure: route on concise skill descriptions, then load only the
+references needed by the selected workflow.
+
+### Intentional behavior changes
+
+v3.0.0 is not byte-for-byte behavioral parity with v2.x. The main changes are:
+
+- `aep-design-lens` is a new skill, bringing the release to 22 AEP skills.
+- Design and calibration use an explicit gather/convergence flow.
+- Heavy/light alignment policy has one canonical owner.
+- Optional distillation can supplement the native lessons loop.
+- Isolated agents receive machine-assembled briefs with stale-base guardrails.
+- Autopilot and executor orchestration are more deterministic.
+- `aep-scaffold` can audit and converge cross-runtime layout drift.
+
+### What does not require migration
+
+- Existing product-context schemas remain readable.
+- The autopilot state version remains compatible.
+- Signal formats do not require a field rewrite.
+- Existing story IDs, dependency graphs, and layer numbers remain authoritative.
+
+Treat unexpected changes under product context or `.dev-workflow/` as migration
+errors, not as expected v3 churn.
+
+## Stop Conditions
+
+Do not start or continue the re-pin when any of these conditions is true:
+
+- The repository contains unrelated uncommitted changes.
+- A story or workspace is still active.
+- An autopilot tick lock exists.
+- Product context says a story is pending while runtime signals say it is active.
+- Claude and Codex contain divergent real copies of the same `aep-*` skill.
+- A stale lock entry cannot be distinguished from an intentionally retained skill.
+- Project CI is already failing for an unexplained reason.
+
+Resolve the condition on the old pin first. Do not use the version upgrade as a
+vehicle for repairing live workflow state or product data.
+
+## Phase 0 — Preflight and Quiesce
+
+### 0.1 Record the old boundary
+
+Run these commands from the downstream repository root and save the output in the
+migration PR description:
+
+```bash
+git rev-parse HEAD
+git status --short --branch
+git worktree list --porcelain
+npx skills list
+```
+
+Also record:
+
+- The AEP version stated in `AGENTS.md`.
+- Whether `.agents/skills/aep-*` are real directories.
+- Whether `.claude/skills/aep-*` are real directories or symlinks.
+- The current story, workspace, autopilot phase, and tick lock.
+
+Do not infer quiescence from an empty terminal window. Use the repository's
+persisted product state, workspace map, and runtime signal together.
+
+### 0.2 Finish the old-pin lifecycle
+
+Before installing v3.0.0:
+
+1. Stop new dispatches.
+2. Let the current story finish, merge, and wrap on the old pin.
+3. Confirm the story is terminal in canonical product context.
+4. Confirm the active workspace map is empty.
+5. Confirm no tick lock remains.
+6. Reconcile any mismatch between product state and runtime signals.
+
+Registered worktrees are not automatically disposable. Inspect them individually;
+an old registration can still contain user work.
+
+After the old-pin lifecycle is terminal, snapshot ignored runtime files so the
+later no-migration check covers more than Git-tracked product context:
+
+```bash
+AEP_RUNTIME_SNAPSHOT="${TMPDIR:-/tmp}/aep-v3-runtime-before-$(basename "$PWD").sha256"
+if [ -d .dev-workflow ]; then
+  find .dev-workflow -type f -exec shasum -a 256 {} + | LC_ALL=C sort
+fi > "$AEP_RUNTIME_SNAPSHOT"
+echo "Runtime snapshot: $AEP_RUNTIME_SNAPSHOT"
+```
+
+### 0.3 Require a clean base
+
+```bash
+test -z "$(git status --porcelain)" || {
+  echo "ERROR: worktree is not clean"
+  exit 1
+}
+```
+
+Create a dedicated branch only after the old lifecycle is terminal:
+
+```bash
+git switch -c chore/aep-v3-repin
+```
+
+## Phase 1 — Re-pin Both Runtimes
+
+Run the installer once per runtime. A repeated `-a` does not install to multiple
+runtimes, so keep these as two commands:
+
+```bash
+npx skills add memorysaver/agentic-engineering-patterns@v3.0.0 \
+  -a claude-code --skill '*' -y
+
+npx skills add memorysaver/agentic-engineering-patterns@v3.0.0 \
+  -a codex --skill '*' -y
+```
+
+The expected result is:
+
+- 22 physical `aep-*` skill packages.
+- A new `aep-design-lens` package.
+- Updated AEP objects and hashes in `skills-lock.json`.
+- No change to non-AEP skills from other sources.
+
+`skills-lock.json` stores content hashes, not the release tag. The durable pin is
+the combination of committed installed bytes, the lockfile, and the human-readable
+pin note in `AGENTS.md`.
+
+## Phase 2 — Converge the Cross-runtime Layout
+
+If the repository uses real AEP directories under `.agents/skills/` and Claude
+symlinks into them, the Claude installer temporarily replaces those symlinks with
+real copies. Normalize the layout only after both installs have completed.
+
+Resolve the installed scaffold path and run its read-only audit:
+
+```bash
+AEP_SCAFFOLD=.agents/skills/aep-scaffold
+if [ ! -f "$AEP_SCAFFOLD/scripts/audit.sh" ]; then
+  AEP_SCAFFOLD=.claude/skills/aep-scaffold
+fi
+
+bash "$AEP_SCAFFOLD/scripts/audit.sh"
+```
+
+The first audit may exit `1` because installation created layout drift. Review the
+category A findings, then converge only that mechanical category:
+
+```bash
+bash "$AEP_SCAFFOLD/scripts/converge.sh" --category A
+bash "$AEP_SCAFFOLD/scripts/audit.sh"
+```
+
+The second audit must exit `0`. The converge script:
+
+- Promotes a Claude-only copy to the canonical Codex location.
+- Collapses copies only when content and file modes match.
+- Refuses to delete either side when copies diverge.
+- Restores `.claude/skills/aep-*` as canonical symlinks.
+
+If it fails closed on divergent copies, compare the two directories and resolve the
+cause manually. Do not choose one side based only on modification time.
+
+Repositories that intentionally keep independent real copies for every runtime must
+review that choice separately; category A converges to the shared canonical layout.
+
+## Phase 3 — Clean the Lock and Pin Metadata
+
+### 3.1 Remove lock-only orphans
+
+The skills CLI updates installed packages but does not necessarily remove a stale
+object that has no physical skill directory. In the audited v2.5.0 downstream,
+`aep-testing-guide` was such an orphan: it was absent from the release and absent on
+disk, but remained in `skills-lock.json`.
+
+Check it explicitly:
+
+```bash
+if [ -e .agents/skills/aep-testing-guide ] || \
+   [ -e .claude/skills/aep-testing-guide ]; then
+  echo "ERROR: inspect the physical aep-testing-guide package before continuing"
+  exit 1
+fi
+
+node - <<'NODE'
+const lock = require("./skills-lock.json");
+if (lock.skills?.["aep-testing-guide"]) {
+  console.error("ERROR: remove the lock-only aep-testing-guide object manually");
+  process.exit(1);
+}
+NODE
+```
+
+If the object is lock-only, remove that object from `skills-lock.json` in the
+migration PR. Do not remove similarly named project-owned skills without tracing
+their source.
+
+### 3.2 Update the prose pin
+
+Change the AEP pin note in `AGENTS.md` from the previous version to `v3.0.0`. The
+installer does not update this hand-written note.
+
+Keep supplemental skills such as `project-memory` or `memory-forge` at their
+existing source and pin unless they are being upgraded in a separate change.
+
+### 3.3 Protect installed bytes
+
+Exclude these paths from Markdown/JSON formatters:
+
+```text
+.agents/skills/**
+.claude/skills/**
+skills-lock.json
+```
+
+Formatting installed bytes after the installer computes their hashes breaks the
+lock. Commit the re-pin with hooks bypassed only after running the checks in this
+guide explicitly.
+
+## Phase 4 — Prove Data Compatibility
+
+### 4.1 Do not rewrite product context
+
+The migration should leave these paths unchanged when they exist:
+
+```text
+product-context.yaml
+design-context.yaml
+product/
+calibration/
+.dev-workflow/
+```
+
+Check the tracked product tree directly:
+
+```bash
+git status --short --untracked-files=all -- \
+  product-context.yaml design-context.yaml product calibration
+git diff --exit-code -- \
+  product-context.yaml design-context.yaml product calibration .dev-workflow
+
+AEP_RUNTIME_SNAPSHOT="${TMPDIR:-/tmp}/aep-v3-runtime-before-$(basename "$PWD").sha256"
+test -f "$AEP_RUNTIME_SNAPSHOT"
+if [ -d .dev-workflow ]; then
+  find .dev-workflow -type f -exec shasum -a 256 {} + | LC_ALL=C sort
+fi | diff -u "$AEP_RUNTIME_SNAPSHOT" -
+```
+
+An empty diff is the expected result. If a formatter or tool changed these files,
+remove those changes from the migration branch and investigate separately.
+
+### 4.2 Parse all YAML
+
+Use the same parser family as AEP's validation checks:
+
+```bash
+bash <<'BASH'
+set -euo pipefail
+
+yaml_files=()
+for file in product-context.yaml design-context.yaml; do
+  [ -f "$file" ] && yaml_files+=("$file")
+done
+for directory in product calibration; do
+  [ -d "$directory" ] || continue
+  while IFS= read -r -d '' file; do
+    yaml_files+=("$file")
+  done < <(find "$directory" -type f -name '*.yaml' -print0)
+done
+
+for file in "${yaml_files[@]}"; do
+  npx --yes js-yaml "$file" >/dev/null
+done
+
+printf 'Validated %s YAML files\n' "${#yaml_files[@]}"
+BASH
+```
+
+This is a syntax check, not a reason to normalize existing values. Preserve
+canonical story and layer semantics.
+
+### 4.3 Preserve runtime state
+
+Do not hand-edit autopilot state to make it look idle. If the state, product story,
+workspace map, and signal disagree, stop and reconcile the old run before cutover.
+
+The v3.0.0 state schema is compatible with the audited v2.5.0 state, but compatibility
+does not make a mid-story model/session handoff safe.
+
+### 4.4 Account for known protocol-document drift
+
+The v3.0.0 `aep-validate` protocol reference still contains legacy prose for some
+canonical product fields. It can describe:
+
+- `description` as a string instead of the canonical object form.
+- `business_value` as text instead of numeric or `null`.
+- `done` instead of the canonical terminal statuses `completed` or `deferred`.
+- Older layer-gate evidence keys.
+
+This drift predates v3.0.0. Do not rewrite valid canonical product data to satisfy
+the stale prose. If a strict checker flags only these known differences, record the
+finding and track the upstream documentation fix separately.
+
+## Phase 5 — Review the Migration Diff
+
+Expected changes are limited to:
+
+- `.agents/skills/aep-*/**`
+- `.claude/skills/aep-*` layout entries
+- `skills-lock.json`
+- The AEP version note in `AGENTS.md`
+
+Expected release-level additions include `aep-design-lens`. Some obsolete reference
+files may disappear because v3 consolidates canonical ownership.
+
+The migration diff must not include:
+
+- Product stories, layers, activities, modules, or calibration output.
+- `.dev-workflow/` state or signals.
+- Application source or tests.
+- Unrelated project-owned or supplemental skills.
+- Formatter-only churn inside installed skill files.
+
+Review both names and modes:
+
+```bash
+git status --short
+git diff --stat
+git diff --summary
+git diff --check
+```
+
+## Phase 6 — Deterministic Verification
+
+### 6.1 Verify inventory and layout
+
+```bash
+npx skills list
+
+test "$(find .agents/skills -mindepth 1 -maxdepth 1 \
+  -type d -name 'aep-*' | wc -l | tr -d ' ')" = "22"
+
+test -f .agents/skills/aep-design-lens/SKILL.md
+
+for link in .claude/skills/aep-*; do
+  test -L "$link"
+  test -e "$link"
+done
+
+AEP_SCAFFOLD=.agents/skills/aep-scaffold
+if [ ! -f "$AEP_SCAFFOLD/scripts/audit.sh" ]; then
+  AEP_SCAFFOLD=.claude/skills/aep-scaffold
+fi
+bash "$AEP_SCAFFOLD/scripts/audit.sh"
+```
+
+If the repository uses a different intentional layout, replace the symlink
+assertions with documented equivalent checks; do not silently skip layout
+verification.
+
+### 6.2 Verify lock completeness
+
+Every physical AEP skill should have one lock object, every AEP lock object should
+have a physical package, and `aep-design-lens` should exist in both sets. A lock-only
+`aep-testing-guide` is a failure.
+
+```bash
+node - <<'NODE'
+const fs = require("node:fs");
+const lock = require("./skills-lock.json");
+
+const physical = fs
+  .readdirSync(".agents/skills", { withFileTypes: true })
+  .filter((entry) => entry.isDirectory() && entry.name.startsWith("aep-"))
+  .map((entry) => entry.name)
+  .sort();
+
+const locked = Object.entries(lock.skills ?? {})
+  .filter(
+    ([name, metadata]) =>
+      name.startsWith("aep-") &&
+      metadata?.source === "memorysaver/agentic-engineering-patterns",
+  )
+  .map(([name]) => name)
+  .sort();
+
+const missingFromLock = physical.filter((name) => !locked.includes(name));
+const missingFromDisk = locked.filter((name) => !physical.includes(name));
+
+if (
+  physical.length !== 22 ||
+  missingFromLock.length ||
+  missingFromDisk.length ||
+  !physical.includes("aep-design-lens")
+) {
+  console.error({ physical: physical.length, missingFromLock, missingFromDisk });
+  process.exit(1);
+}
+
+console.log("AEP inventory: 22 physical packages matched by 22 lock objects");
+NODE
+```
+
+The installed skill bytes are the authoritative pin. Do not run a formatter or an
+unversioned restore command between installation and commit.
+
+### 6.3 Run project checks
+
+Run the downstream repository's normal CI-equivalent checks, then:
+
+```bash
+git diff --check
+```
+
+All pre-existing failures must be explained in the PR. Do not classify a newly
+introduced failure as unrelated without reproducing it on the old pin.
+
+## Phase 7 — Commit and Merge
+
+Stage only the migration paths:
+
+```bash
+git add .agents/skills .claude/skills skills-lock.json AGENTS.md
+git diff --cached --check
+git commit --no-verify -m "chore: re-pin AEP skills to v3.0.0"
+```
+
+The `--no-verify` flag protects pinned bytes from formatter hooks; it is not a
+substitute for the explicit checks above.
+
+The PR description should include:
+
+- Old commit and AEP pin.
+- Confirmation that the old story/workspace lifecycle was terminal.
+- Before/after skill counts.
+- Scaffold audit result.
+- Product-tree no-diff result.
+- YAML validation count.
+- CI results.
+- The planned canary and rollback owner.
+
+Merge only when deterministic checks are green and no workflow process is still
+using the old pin.
+
+## Phase 8 — Post-merge Canary
+
+### 8.1 Start fresh sessions
+
+Close or discard agent sessions that loaded v2.x skill metadata. Start new Claude
+Code and Codex sessions from the merged commit so routing descriptions, references,
+and installed bytes all come from v3.0.0.
+
+### 8.2 Run routing canaries
+
+Use representative prompts and confirm the front-tier router selects the intended
+skill before allowing autonomous execution:
+
+| Canary intent                                    | Expected route                      |
+| ------------------------------------------------ | ----------------------------------- |
+| Install or converge an existing project          | `aep-onboard` / `aep-scaffold`      |
+| Choose and launch the next product story         | `aep-dispatch` / `aep-autopilot`    |
+| Evaluate a design decision or alignment          | `aep-design-lens` / `aep-calibrate` |
+| Validate context or generate evaluation evidence | `aep-validate` / `aep-gen-eval`     |
+
+The release contains direct/boundary routing observations and dry-run behavior
+scenarios, but not a same-model v2.5.0-versus-v3.0.0 A/B benchmark. Treat downstream
+canary evidence as required, not optional reassurance.
+
+### 8.3 Bound the rollout
+
+For the first one or two v3 stories:
+
+1. Rehearse the next dispatch read-only.
+2. Confirm the prior layer gate is satisfied.
+3. Confirm story, activity, and module references resolve.
+4. Observe workspace creation and the first executor handoff.
+5. Confirm signals and canonical product state stay consistent.
+6. Inspect the first v3 wrap/convergence result before widening autonomy.
+
+Do not combine the first v3 run with a schema rewrite or a large product-context
+cleanup. Separate changes make routing or orchestration regressions diagnosable.
+
+## Rollback
+
+Rollback is appropriate when deterministic verification passed but the canary shows
+a routing, orchestration, or stability regression attributable to v3.0.0.
+
+1. Stop new dispatches.
+2. Let any already-started write settle, or preserve its signals and workspace for
+   investigation.
+3. Revert the merged re-pin commit or PR with `git revert <merge-sha>`.
+4. Run the old-pin deterministic checks.
+5. Start fresh agent sessions from the reverted commit.
+6. Record the failing prompt, selected route, loaded references, runtime state, and
+   expected behavior before retrying the upgrade.
+
+Do not use `git reset --hard` as a migration rollback. A revert preserves the audit
+trail and avoids destroying canary work. Because the migration PR excludes product
+data, rollback should affect only installed skills, layout entries, the lockfile,
+and the prose pin.
+
+## Looplia-specific Cutover Gate
+
+The July 15 compatibility audit found Looplia structurally compatible with v3.0.0,
+but not yet at a safe runtime cutover boundary. Before applying this guide there:
+
+1. Finish, merge, and wrap `FIX-L31-DOGFOOD-SECRETS-001` on v2.5.0.
+2. Reconcile its pending canonical story state with the active runtime signal.
+3. Resolve or explicitly map its missing `e2e-verification` module reference.
+4. Confirm the active workspace map and tick lock are empty.
+5. Inspect all 29 registered worktrees; do not delete them in bulk.
+6. Remove the lock-only `aep-testing-guide` object during the re-pin.
+7. Keep all product-context YAML byte-for-byte unchanged.
+8. After merge, prove the Layer 31 gate and rehearse Layer 32 dispatch read-only
+   before resuming autopilot.
+
+The audit also found stale module/activity references concentrated in terminal
+history. Those are cleanup findings, not reasons to mutate history inside the v3
+migration PR.
+
+## Final Checklist
+
+- [ ] Old-pin story is terminal and wrapped.
+- [ ] Active workspace map is empty.
+- [ ] Tick lock is absent.
+- [ ] Migration started from a clean branch.
+- [ ] Claude Code and Codex were each installed at exact tag `v3.0.0`.
+- [ ] Category A layout convergence completed without ambiguity.
+- [ ] Exactly 22 physical AEP skills exist, including `aep-design-lens`.
+- [ ] No lock-only `aep-testing-guide` object remains.
+- [ ] `AGENTS.md` states `v3.0.0`.
+- [ ] Product context and `.dev-workflow/` have no migration diff.
+- [ ] All product/calibration YAML parses.
+- [ ] Scaffold audit exits `0`.
+- [ ] Project CI and `git diff --check` pass.
+- [ ] Migration PR contains only pin/layout metadata.
+- [ ] Fresh sessions are used after merge.
+- [ ] Routing and first-story canaries pass before full autonomy resumes.
+- [ ] Rollback owner and merge SHA are recorded.
+
+## Related Documentation
+
+- [README: upgrading to a new release](../README.md#upgrading-to-a-new-release)
+- [Skill authoring standard](decisions/skill-authoring-standard.md)
+- [Build convergence pipeline](decisions/build-convergence-pipeline.md)
+- [Deterministic orchestration](decisions/deterministic-orchestration.md)
+- [Lean skills refactor plan](plans/2026-07-14-lean-skills-refactor.md)
+- [Looplia compatibility audit](audits/2026-07-15-looplia-v2.5.0-to-v3.0.0-compatibility.md)

--- a/docs/article/three-mechanisms-against-verifier-gaming.md
+++ b/docs/article/three-mechanisms-against-verifier-gaming.md
@@ -1,0 +1,256 @@
+# Three Mechanisms Against Verifier Gaming in Autonomous Development Loops
+
+_Distilled from the [verification-economics decision](../decisions/verification-economics.md)
+(AEP v3.1.0/v3.2.0). Written as self-contained material for sharing outside this repo; the
+evidence, review trail, and implementation contract live in the decision doc and PR #24._
+
+---
+
+Autonomous development loops — an LLM agent that plans, implements, evaluates, and merges its own
+work — have a verification problem with two faces that are usually discussed separately:
+
+- **Cost.** Verification quietly becomes the dominant spend. In one of our production loops, only
+  16 of the last 100 commits carried product code; the other 84 were process, evaluation, and
+  archival overhead. In another, a single UI story consumed two formal evaluator rounds at the most
+  expensive model profile available, two ~13-minute full-suite runs, six end-to-end scenarios, and
+  a verification ledger — for a display-positioning change. Test code ran 1.56× the feature code.
+- **Gaming.** As generator models get stronger, every check that can be satisfied without
+  satisfying its intent eventually will be. The RLVR literature documents models that curl answers
+  from GitHub, hunt for hidden test files, and patch code against secret test cases — not solving
+  the task, optimizing the reward signal. Goodhart's law, executed by an agent with a shell.
+
+The standard responses pull in opposite directions: cut cost by verifying less (and get gamed
+more), or resist gaming by adding more LLM-judge rounds (and pay more for a check that a stronger
+model games anyway). The observation that reframes both:
+
+> **An LLM-judge round is the only validator class that gets simultaneously more expensive and
+> more gameable as models improve.**
+
+Everything else — a typecheck, a schema validation, a secret scanner, a real deployment exercised
+end-to-end, production telemetry — gets relatively cheaper and stays exactly as hard to fool. So
+the design goal is not "more verification" or "less verification." It is **moving verification
+spend from repeated LLM judgment onto deterministic gates and tamper-evident evidence, and
+concentrating the judgment you keep at the few boundaries where it is decisive.**
+
+We rebuilt the verification layer of an autonomous-development methodology (AEP) around that goal,
+then had the design adversarially reviewed four times — including an independent frontier-model
+evaluation benchmarked against Anthropic's published agent-engineering guidance, the
+RLVR/reward-hacking literature, and classical DevOps/SDLC theory (shift-left, the test pyramid,
+risk-based testing, SRE error budgets). The evaluation's verdict was "aligned with gaps," most of
+which we folded back in. It also produced a strict list of mechanisms it **could not map to any
+published practice**. There were three. This article is about those three.
+
+## The incident that motivated everything
+
+One number first, because the design is empirical, not aesthetic.
+
+A production autonomous loop (a Cloudflare-based product building itself through an AI-driven
+story pipeline) hit a failed end-to-end verification against its production environment. The cause
+was purely environmental: two secrets missing from CI, and a local OAuth session bound to the
+wrong cloud account. Nothing in the product was broken.
+
+The loop had exactly one path for a failed verification: file a code-fix story and push it through
+an independent evaluation loop capped at five rounds. So it did — twice. Both recovery stories
+exhausted all five evaluation rounds and still failed (final scores 2.79 and 3.28 out of 5,
+because no code change can conjure a missing secret). The autopilot then halted for human
+redesign at tick 444. **Ten independent evaluation rounds, two synthetic stories, and a full
+production halt were spent on a problem whose fix was "set two secrets and re-auth the CLI."**
+
+The same loop had also, at some point, ratcheted its merge gate to "the independent evaluator must
+return exactly 5.00/5.00 with zero findings" — a lesson-learned reaction to one bad round that is
+textbook Goodhart bait: a perfect-score gate trains the generator to satisfy the evaluator, not
+the product, and turns ordinary convergence into round exhaustion.
+
+Cost and gaming, one incident. The three mechanisms below are the parts of the fix that turned out
+to be original.
+
+---
+
+## Mechanism 1: Classification Authority
+
+**The problem.** Any mature verification loop needs a failure taxonomy — this failure is a product
+defect, that one is a broken environment, that one is a flaky harness, that one is a mis-scoped
+requirement. Routing on the taxonomy is what prevents the ten-round incident above: environment
+failures go to an ops checklist, never into code-repair machinery.
+
+But the moment the taxonomy exists, it is an attack surface. If the agent whose work just failed
+gets to classify the failure, then "the test is flaky" — the oldest excuse in software — becomes a
+**sanctioned, typed escape hatch**. Label your product defect `harness-flake` and the failing test
+gets quarantined. Label it `environment` and no evaluation round is ever spent on it. The
+classifier is the player, the referee, and the witness at once.
+
+**The mechanism.** Every failure class that _reduces_ verification spend carries an evidence
+requirement that the generator cannot manufacture, and anything without qualifying evidence
+defaults to the most expensive class:
+
+| Class            | Claimable by                                                                                                                                                                                         |
+| ---------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `environment`    | **Only** a named refusal tag from a deterministic preflight probe (`REFUSING [dogfood-secret-absent:<NAME>]`). No tag → not environment.                                                             |
+| `harness-flake`  | World-derivable reproduction evidence (a same-SHA re-run that passes with zero diff, or membership in an orchestrator-owned quarantine list), ratified by a non-generator role — never self-applied. |
+| `scope`          | A human acknowledgment on the escalation record before the routing takes effect.                                                                                                                     |
+| `product-defect` | The default. Requires no evidence — it is the class that spends verification.                                                                                                                        |
+
+The load-bearing properties:
+
+- **Environment is claimable only by construction.** The preflight probe runs _before_ any
+  verification spend; a refusal means zero scenarios executed, zero findings generated, zero
+  rounds burned. The classification is not a judgment call anyone makes — it is what the world
+  said. Nobody argued the looplia incident into the environment class; a probe that checks "does
+  the secret name exist in CI" refuses, and the classification follows.
+- **The cheap classes are ratified, never self-applied.** A flake claim needs a reproduction the
+  world can verify, and a second, differently-incentivized role signs it off.
+- **The default is the expensive class.** Fail-open here is also the tamper-resistance rule: an
+  unclassifiable failure spends verification rather than dodging it.
+- **Classification is per-finding, not per-incident**, with an ownership check: if the unmet
+  precondition is created by artifacts in the repo (deploy config that never wired a binding), the
+  environment refusal is _paired_ with a product-defect finding — the ops path cannot be used to
+  mask defects behind hand-repair.
+
+Pieces of this exist in industry — flaky-test quarantine bots, blameless-postmortem taxonomies —
+but the systematic, adversarially-motivated **evidence-requirement-per-class table with an
+expensive default**, designed for a generator that will exploit any cheaper label, does not appear
+in Anthropic's guidance, the RLVR literature, or ISTQB-style test-management practice. The
+principle generalizes past failure classification: **any label that reduces oversight must come
+from a non-generator role or from world-derivable evidence.**
+
+## Mechanism 2: Two-Point Monotone Risk Derivation
+
+**The problem.** Uniform verification depth is what makes loops unaffordable — a display-tweak
+story does not need the same gauntlet as a payment-flow story. Risk-based testing is decades old:
+classify the change, scale the verification. But in an autonomous loop, the risk classification
+itself is generator-influenceable. The story plan's declared scope (`files_affected`) is a
+_prediction authored by the same planning pipeline that will be graded_. Derive the verification
+tier from the plan and one under-declared field simultaneously lowers the tier, dodges the
+security floor, and shrinks the regression-replay set. Three escapes from one soft field.
+
+**The mechanism.** Derive twice, and let the tier move in only one direction:
+
+1. **Provisional (planning time).** Derived from the plan's declared scope, complexity, and layer.
+   This prices the build — evaluator effort, dogfood scope — but it is understood to be a
+   prediction, and nothing security-relevant hangs on it.
+2. **Binding (first consumption point).** Re-derived from the **actual diff**
+   (`git diff --name-only $BASE...HEAD` — world-derived fact, not declaration) against a
+   **human-owned sensitive-path list**, at the moment the first evaluation round would spend the
+   budget — not later at merge, or the whole evaluation loop runs on the gameable provisional
+   tier. If the diff left the declared scope, the tier is recomputed from the diff and the drift
+   is recorded.
+3. **Monotonicity.** At binding — and at every re-check after post-review commits — **the tier may
+   only go up, never down.** A story cannot talk its way into a cheaper class by under-declaring;
+   the worst under-declaration can do is trigger an upgrade.
+
+And the completing piece, which an independent adversarial review caught us missing: **referee
+assets never derive the cheap tier.** Test directories, journey specifications, verification
+policy files, CI workflow definitions — these are the evidence base every later verifier stands
+on. A "tests-only diff" is not a low-risk diff; it is a change to the referee. So diffs confined
+to referee assets floor at the standard tier, and a **negative assertion delta** (more test
+assertions deleted than added) always forces an evaluation round, whatever the tier. Without this
+rule, the taxonomy from Mechanism 1 funnels work straight into the hole: a quarantined flake spawns
+a harness story, harness stories are tests-only, tests-only was cheapest.
+
+Risk re-assessment at execution time exists in ISTQB practice. The adversarial **plan-versus-world
+framing with an up-only ratchet** — treating the plan as a gameable prediction, the diff as
+admissible evidence, and monotonicity as the tamper-resistance property — is the original part.
+
+## Mechanism 3: The Verification Recipe Ratchet
+
+**The problem.** Depth (how many evaluation rounds, how much dogfooding) is only half of
+verification cost. The other half is **composition**: which dimensions the evaluator scores —
+security, completeness, correctness, UX, visual design — and which dimension-level hard floors
+apply. Rubric presets per artifact type are standard practice. But if preset selection is a
+separate judgment from risk derivation, the two decouple exactly where it hurts: a story that
+touches authentication paths can derive the deepest tier while its evaluator runs a generic
+mixed-purpose rubric **without the Security ≥ 4 hard floor** — maximum depth, missing angle.
+Meanwhile the most expensive dimension (visual design: screenshot capture plus multimodal
+evaluation) runs out of habit on stories that ship no UI.
+
+**The mechanism.** One derivation emits one **verification recipe** — tier + dimension preset +
+dimension hard floors — from one set of world-derived inputs:
+
+- a sensitive-path match selects the security-sensitive preset **and folds its dimension floors
+  (Security ≥ 4, Data Privacy ≥ 4) into the tier's hard floor**, where no customization can remove
+  them — it also attaches the deterministic security gates (secret scan, SAST) as inner-loop
+  checks, because the mechanically detectable half of security should never be routed to a more
+  expensive LLM judge;
+- UI-surface signals (UI-kind module, visual-design calibration references) select the UI preset —
+  and **only those stories pay for the multimodal visual-design dimension**. Dimension cost
+  follows the shipped surface, never habit;
+- data/migration paths select the data-integrity preset; planning artifacts select the
+  product/design dimensions; everything else runs the default.
+
+Then the ratchet: **customization may add dimensions or raise thresholds, and may never drop a
+derived hard floor.** Same direction as Mechanism 2, applied to rubric composition. Per tier, the
+cheap tier scores no dimensions (self-review), the standard tier runs the derived preset, and the
+deep tier runs it with nothing de-weighted — preferably judged by a **different model family from
+the generator**, because cross-family judging decorrelates the blind spots.
+
+The closing loop: findings and post-merge escapes are recorded **per dimension**, so the old
+advice "weight scoring dimensions toward where the model falls short" stops being intuition and
+becomes something a calibration pass can propose from evidence.
+
+Risk-based test _planning_ is established practice. Deriving the **evaluator's rubric composition
+from the same world-derived signal as its depth, with tamper-resistant floors and
+surface-following dimension cost**, is not something we could find published anywhere.
+
+---
+
+## What the three share
+
+Each mechanism is the same move applied to a different attack surface:
+
+| Mechanism                | Gameable input it replaces      | World-derived fact it substitutes                | Ratchet direction                     |
+| ------------------------ | ------------------------------- | ------------------------------------------------ | ------------------------------------- |
+| Classification authority | The failing agent's own account | Probe refusal tags; same-SHA reproductions       | Default = most expensive class        |
+| Two-point derivation     | The plan's declared scope       | The merged diff vs. a human-owned sensitive list | Tier only escalates                   |
+| Recipe ratchet           | Launch-time rubric judgment     | The same diff-derived signals as the tier        | Floors only rise; dimensions only add |
+
+Or as one sentence: **in an autonomous loop, any input that lowers oversight must be a fact the
+world produced, not a claim the agent authored — and every knob ratchets toward more scrutiny by
+default, with loosening reserved for an evidence-fed, human-ratified calibration pass.**
+
+That last clause matters. The point of all this is _lower_ total verification cost, not higher —
+the loops that motivated it were drowning in verification (84% process commits; a verification
+corpus that only ever grew). The mechanisms are what make cheap verification _safe_: you can run
+one decisive evaluation round instead of five, skip the multimodal rubric on a backend story, and
+route an ops failure around the repair machinery entirely — precisely because the classification,
+the tier, and the rubric are no longer the generator's word to give.
+
+Replayed against the motivating incident: the missing secret is caught by a name-only probe before
+any merge, the wrong-account binding refuses at the gate with a named tag, the hardcoded password
+fallback that had been sitting in four scripts is caught by the inner-loop secret scanner on the
+first commit that introduced it, and the two never-should-have-existed recovery stories never
+exist. The loop still pauses — humans still have to set secrets — but it pauses immediately,
+cheaply, and correctly labeled, instead of after ten evaluation rounds of trying to code its way
+out of a configuration problem.
+
+## Provenance and honest limits
+
+This design was produced by an AI-assisted research loop and then reviewed four times before
+implementation: a three-lens subagent design review (factual grounding against the repo,
+adversarial critique, downstream operability against the two consumer projects), a trigger-path
+trace through the orchestration chain, a rubric-coupling review, and an independent
+frontier-model evaluation. Several of the mechanisms' load-bearing details — the referee-asset
+rule, binding-at-first-consumption, the expensive default — were **added because a review broke
+the earlier version**, which is some evidence the adversarial process works on designs and not
+just code.
+
+The evaluation that certified the three mechanisms as unmapped-to-published-practice also scored
+the overall design "aligned with gaps" — 3/5 on simplicity, with a pointed critique we accepted:
+the mechanical core of these rules must ship as typed artifacts and runnable reference
+implementations, not prose an agent is supposed to remember, or they will drift exactly like every
+other prose invariant. And the economics half (tiers, recipes, calibration) rests on thinner
+evidence than the taxonomy half, so it ships a release later, gated on field data. Claims about
+what is "original" are as of the evaluation date (2026-07-16) and bounded by what one
+well-benchmarked model could map; treat them as "we looked hard and could not find it," not as a
+literature review.
+
+## Sources
+
+- [Verification-economics decision doc](../decisions/verification-economics.md) — the full design,
+  evidence citations, and the v3.1.0/v3.2.0 implementation contract.
+- [Deterministic orchestration](../decisions/deterministic-orchestration.md) — the companion
+  empirical law (prose invariants drift; typed gates never did) these mechanisms extend from
+  orchestration to verification.
+- Anthropic, ["Harness Design for Long-Running Application Development"](https://www.anthropic.com/engineering/harness-design-long-running-apps)
+  — the generator/evaluator separation these mechanisms build on.
+- The incident and cost data come from two production AEP consumer loops (a Cloudflare
+  auto-company platform and a TUI control-surface product building itself), gathered 2026-07-16.

--- a/docs/article/three-mechanisms-against-verifier-gaming.md
+++ b/docs/article/three-mechanisms-against-verifier-gaming.md
@@ -95,8 +95,8 @@ The load-bearing properties:
 - **Environment is claimable only by construction.** The preflight probe runs _before_ any
   verification spend; a refusal means zero scenarios executed, zero findings generated, zero
   rounds burned. The classification is not a judgment call anyone makes — it is what the world
-  said. Nobody argued the looplia incident into the environment class; a probe that checks "does
-  the secret name exist in CI" refuses, and the classification follows.
+  said. Nobody argues the motivating incident into the environment class; a probe that checks
+  "does the secret name exist in CI" refuses, and the classification follows.
 - **The cheap classes are ratified, never self-applied.** A flake claim needs a reproduction the
   world can verify, and a second, differently-incentivized role signs it off.
 - **The default is the expensive class.** Fail-open here is also the tamper-resistance rule: an

--- a/docs/audits/2026-07-15-looplia-v2.5.0-to-v3.0.0-compatibility.md
+++ b/docs/audits/2026-07-15-looplia-v2.5.0-to-v3.0.0-compatibility.md
@@ -1,0 +1,362 @@
+# Looplia downstream compatibility audit: AEP v2.5.0 → v3.0.0
+
+**Audit date:** 2026-07-15 (Asia/Taipei)  
+**AEP baseline:** `v2.5.0` (`9414b24f8f6c252b7b5c79b70f7a21120f7c8d29`) → `v3.0.0` (`83ffb4d1ef3b7ac4edea977678d2ded50a4bdf82`)  
+**Downstream baseline:** looplia `main` at `12a3bef942c92b9276fa2a118356da8cbffbd921`  
+**Downstream path inspected:** `/Users/memorysaver/Documents/github/looplia`
+
+## Executive verdict
+
+**Looplia is conditionally compatible with AEP v3.0.0.** Its product-context data, split-file layout,
+autopilot state, signal contract, project-owned e2e skill, and cross-runtime skill layout can all be
+consumed by v3.0.0 without a data migration. A scratch-clone re-pin installed all 22 v3 skills, converged
+the Claude/Codex layout, passed the v3 scaffold audit, preserved the product tree byte-for-byte, and
+parsed all 34 product/calibration YAML files.
+
+The upgrade is **not behaviorally identical** and should **not be merged while the current v2.5 worker is
+in flight**. The safe disposition is:
+
+| Area                                | Result                          | Meaning                                                                                                                  |
+| ----------------------------------- | ------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| Product-context structure and YAML  | **GREEN**                       | No schema migration required; v3 detects looplia as Split mode.                                                          |
+| Story graph and active queue        | **YELLOW**                      | DAG and fields pass, but the in-flight recovery story has both a missing module definition and cross-plane status drift. |
+| Autopilot state and signal files    | **GREEN**                       | State schema is byte-identical between tags; signal-spec change is prose-only.                                           |
+| Installed-skill/layout re-pin       | **GREEN after converge**        | Both runtimes reach the same 22 v3 skill bytes; category A converge is required after the Claude install.                |
+| Agent routing/execution equivalence | **YELLOW**                      | v3-only routing and scenario evidence passes, but no same-model v2.5-vs-v3 A/B run exists.                               |
+| Immediate cutover today             | **RED until terminal boundary** | Autopilot is `running` with one v2.5 workspace; old worktrees retain old skill bytes.                                    |
+
+Recommended decision: **approve a controlled v3.0.0 re-pin after the current Layer 31 recovery story reaches
+merge + wrap and the autopilot workspace map is empty.** Do not mutate the current looplia checkout in
+place.
+
+## Scope and method
+
+This audit answers four separate questions:
+
+1. Are the bytes installed in looplia actually the stated v2.5.0 baseline?
+2. Which v2.5.0 → v3.0.0 differences only change context loading, and which intentionally change agent behavior?
+3. Can v3 read looplia's real product context, calibration, object-model, story graph, layer gates, and runtime state?
+4. Does the documented re-pin procedure converge on a copy of the real project without touching product data?
+
+Evidence gathered:
+
+- exact tag-to-tag Git diff and per-skill frontmatter/line metrics;
+- byte comparison of every installed looplia AEP `SKILL.md` against tag `v2.5.0`;
+- YAML parsing with the v3-prescribed `npx js-yaml` path;
+- programmatic cross-file checks for IDs, dependencies, cycles, layers, activities, modules, calibration
+  dimensions, object-map references, and active dispatch gates;
+- direct comparison of product-context template, autopilot state schema, and signal spec across tags;
+- v3 `aep-scaffold/scripts/audit.sh` against the real looplia checkout (read-only);
+- a tracked-HEAD scratch clone using skills CLI `1.5.13`, two runtime installs at `@v3.0.0`, v3 category A
+  converge, post-converge audit, exact installed-byte checks, YAML revalidation, and product-tree diff.
+
+`mgrep` was attempted first as required by the local instructions, but returned monthly-quota `429` in
+both repositories. Local semantic/file discovery therefore degraded to read-only `rg`, Git plumbing, and
+purpose-built parsers. No files in the real looplia checkout were changed.
+
+## Baseline integrity
+
+### What looplia is actually running
+
+- Looplia's `AGENTS.md` states AEP `v2.5.0`.
+- The v2.5.0 marketplace contains **21** AEP skills.
+- Looplia has those same 21 physical AEP skill directories in `.agents/skills/`; every installed
+  `SKILL.md` byte-matches its v2.5.0 source.
+- `.claude/skills/aep-*` correctly points to the real `.agents/skills/aep-*` copies.
+- Looplia's `skills-lock.json` contains **22** AEP entries because it also contains a stale
+  `aep-testing-guide` entry. That path was not in the v2.5.0 marketplace and no physical installed skill
+  exists. This is lockfile drift, not an installed behavior dependency.
+
+This makes v2.5.0 a valid comparison baseline while also explaining why lock-entry counts must not be
+treated as installed-skill counts.
+
+## Design delta
+
+### Front-tier and token footprint
+
+The direct v2.5.0-to-v3.0.0 comparison is smaller than the release document's v2.7-to-v3 lean baseline
+because v2.5.0 did not yet include `aep-design-lens`:
+
+- public skills: **21 → 22**;
+- total public `SKILL.md` lines: **7,816 → 4,873** (**-37.7%**) despite the additional skill;
+- always-loaded description words: **1,522 → 652** (**-57.2%**);
+- all v3 public skill fronts are below 400 lines.
+
+Per-skill line comparison:
+
+| Skill                       | v2.5.0 | v3.0.0 | Delta |
+| --------------------------- | -----: | -----: | ----: |
+| `aep-build`                 |    955 |    348 |  -607 |
+| `aep-autopilot`             |    718 |    348 |  -370 |
+| `aep-dispatch`              |    633 |    325 |  -308 |
+| `aep-scaffold`              |    700 |    398 |  -302 |
+| `aep-launch`                |    476 |    224 |  -252 |
+| `aep-validate`              |    455 |    220 |  -235 |
+| `aep-onboard`               |    385 |    269 |  -116 |
+| `aep-reflect`               |    296 |    182 |  -114 |
+| `aep-calibrate`             |    281 |    177 |  -104 |
+| `aep-wrap`                  |    268 |    164 |  -104 |
+| `aep-map`                   |    355 |    260 |   -95 |
+| `aep-design`                |    187 |    107 |   -80 |
+| `aep-executor`              |    219 |    140 |   -79 |
+| `aep-workflow`              |    187 |    110 |   -77 |
+| `aep-envision`              |    247 |    170 |   -77 |
+| `aep-watch`                 |    318 |    278 |   -40 |
+| `aep-model`                 |    230 |    193 |   -37 |
+| `aep-gen-eval`              |    149 |    118 |   -31 |
+| `aep-git-ref`               |    319 |    298 |   -21 |
+| `aep-e2e-skill-scaffolding` |    265 |    251 |   -14 |
+| `aep-workflow-feedback`     |    173 |    162 |   -11 |
+| `aep-design-lens`           |      — |    131 |  +131 |
+
+The reduction is primarily **progressive disclosure**, not deletion of the lifecycle: the step skeleton
+and postconditions remain in `SKILL.md`; scoring, evaluator contracts, backend recipes, schemas, and
+branch-specific detail move behind named references. Canonical ownership and the rationale are recorded
+in [the authoring standard](../decisions/skill-authoring-standard.md) and the
+[lean refactor plan](../plans/2026-07-14-lean-skills-refactor.md).
+
+### Intentional behavior changes between these two tags
+
+The v3 lean pass aims for step-semantic parity, but a v2.5.0 → v3.0.0 jump also includes v2.6.0 and
+v2.7.0. The following changes are therefore real, intended behavior changes rather than token-only moves:
+
+| Area                  | v2.5.0 behavior                                    | v3.0.0 behavior                                                                       | Downstream effect                                                                                      |
+| --------------------- | -------------------------------------------------- | ------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------ |
+| Design review routing | No theory-owned UI review skill                    | New `aep-design-lens`; calibrate remains taste capture and model remains object IA    | Some generic “design/usability/accessibility review” prompts should intentionally select a new skill.  |
+| Wrap/archive          | Lessons copy, then teardown                        | Convergence Gather runs before archive and writes best-effort execution records       | New archive files; missing old signals degrade to explicit `null`, so old workspaces remain wrappable. |
+| Layer completion      | No layer-level distillation pipeline               | Isolated retrospective + proposal-only distillation can fire once per completed layer | New learned artifacts and one additional bounded agent action at layer completion.                     |
+| Reflect/watch         | Existing feedback/telemetry sources                | Optional `distillation` source adapter                                                | Existing files remain valid; new source is inactive until artifacts exist.                             |
+| Dispatch/launch       | Critical prompt content partly recalled from prose | Machine-assembled briefs, stale-base naming, worktree self-checks                     | More fail-closed abort/rebase behavior; lower risk of launching from a stale integration base.         |
+| Autopilot             | Same state machine, softer prose invariants        | Named ordering invariants and world-derived postconditions                            | Fewer skipped wrap/launch steps; observable state schema is unchanged.                                 |
+| Scaffold              | Large model-driven existing-project flow           | Read-only audit plus idempotent, fail-closed converge scripts                         | Upgrade layout becomes mechanically testable; divergent copies are preserved instead of guessed over.  |
+
+The Convergence Gather compatibility rule is explicit: every missing source is skipped or recorded as
+`null`, never treated as a wrap failure. This is what allows a v2.5-generated worktree to be wrapped by
+v3 if absolutely necessary, although a clean terminal-boundary cutover is still safer.
+
+### Routing and reaction risk
+
+V3 descriptions are materially shorter and more contrastive. The highest-confusion boundaries now say
+which sibling to prefer (`onboard` vs `scaffold`, `dispatch` vs `autopilot`, `calibrate` vs
+`design-lens`). This should reduce token use and synonym-driven ambiguity, but it can change automatic
+selection even when the user's words are unchanged.
+
+Available evidence:
+
+- [routing observations](../../evals/skill-routing-observations.json) record 36 direct/boundary
+  selections using the exact v3 description digest; all selected the intended v3 skill;
+- [behavior parity observations](../../evals/skill-behavior-parity.json) record one dry-run scenario for
+  each of 22 v3 skills, including loaded references and postconditions.
+
+Limits of that evidence:
+
+- routing was recorded for **v3 only**, not as a same-model A/B against v2.5;
+- the serving snapshot is not exposed;
+- the 22 behavior cases are review dry-runs, not repeated runtime distributions over looplia prompts;
+- progressive disclosure adds one dependency on agent compliance: the agent must load the disclosed
+  branch reference. Critical isolated-agent inputs such as dispatch scoring are machine-assembled to
+  reduce this risk, but not every advisory reference is mechanically forced.
+
+Therefore the defensible claim is **contract compatibility with bounded reaction risk**, not identical
+agent behavior.
+
+## Looplia product-context compatibility
+
+### Structural checks
+
+| Check                            | Evidence                                                                                                                     | Result                                                                                                                                                                 |
+| -------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| File resolution                  | Both `product/index.yaml` and `product-context.yaml` exist                                                                   | **Split mode**, exactly as v3 resolves it.                                                                                                                             |
+| Stable vs operational separation | Index has `opportunity`, `personas`, `capabilities`, `product`; root has none of `opportunity`/`product`                     | Pass.                                                                                                                                                                  |
+| Product schema delta             | Tag diff changes only the comment on `topology.routing.watch.sources` to include `distillation`                              | No data-field migration.                                                                                                                                               |
+| YAML parsing                     | Root files plus 32 files under `product/` and `calibration/`                                                                 | **34/34 pass** with `npx js-yaml`.                                                                                                                                     |
+| Story graph                      | 384 stories, 49 layers, 42 activities, 32 architecture modules                                                               | No duplicate story IDs, missing dependencies, cycles, or invalid layer references.                                                                                     |
+| Active queue                     | Main product context has 53 `pending` stories across Layers 31–39                                                            | Required fields are non-null and formal calibration/object-map gates report no active failure, but one of these stories is already running according to runtime state. |
+| Calibration dimensions           | Every `calibration.plan[].dimensions[]` value exists in `product.quality_dimensions[]`                                       | Pass.                                                                                                                                                                  |
+| Object references                | One approved object map; the existing story reference resolves to an object and coverage entry                               | Pass.                                                                                                                                                                  |
+| Layer gates                      | Every active layer has a gate using the current canonical `test_definition`/`journeys`/`coverage`/`evidence`/`results` shape | Pass against the canonical template.                                                                                                                                   |
+
+### Existing semantic drift
+
+The data is runtime-compatible, but a strict protocol validation will encounter historical drift:
+
+- 62 stories reference activities no longer present in `product.activities`; all 62 are terminal.
+- 94 stories reference modules no longer present in `architecture.modules`; 93 are terminal.
+- The one active exception is `FIX-L31-DOGFOOD-SECRETS-001` with module `e2e-verification`. It is already
+  in progress, but a new dispatch-context assembly cannot find a matching module definition.
+- That story is `pending` with `assigned_to: null` and `dispatched_at_epoch: null` in both main and the
+  worktree's product-context copy, while autopilot state records an active workspace and the workspace
+  signal records `story_status: in_progress`. This is a real control-plane drift, not a YAML problem.
+- All 384 story descriptions use the canonical structured form (`what_changes` + `why`). Business value
+  is mixed across project history: 209 numeric, 129 legacy strings, 46 null.
+
+The last two shapes expose a pre-existing AEP documentation inconsistency:
+
+- `validate/references/protocol-specs.md` says `description` is a string, `business_value` is a textual
+  criticality, the terminal status is `done`, and layer gates use `name/tests/pass_criteria/blocks`;
+- the canonical product-context template uses structured descriptions, numeric-or-null business value,
+  `in_review → completed` plus `deferred`, and the richer layer-gate evidence shape that looplia uses.
+
+The protocol document's only v2.5.0 → v3.0.0 diff is replacing a duplicated scoring formula with a
+pointer, so this inconsistency was **not introduced by v3**. It can nevertheless produce protocol-checker
+false positives after upgrade and should be fixed upstream separately. Until then, treat the canonical
+template and dispatch scoring reference as authoritative and classify these validator findings as known
+contract drift rather than rewriting looplia's working data to the stale protocol prose.
+
+## Runtime-state and cutover compatibility
+
+### Compatible state
+
+- `.dev-workflow/autopilot-state.json` parses and declares `version: 1`.
+- `autopilot/references/state-schema.md` is byte-identical between v2.5.0 and v3.0.0.
+- `launch/references/signals-spec.md` changes only one cross-skill path into `/aep-executor` prose; no
+  signal field changed.
+- V3 wrap's new convergence record is best-effort when old workspace files are missing.
+
+### Current in-flight hazard
+
+At audit time:
+
+- autopilot status is `running`, tick 345, with no held tick lock;
+- one workspace, `fix-l31-dogfood-secrets-001`, is `in_progress` on backend `codex-subagent`;
+- autopilot's cached workspace entry still says Phase 0, while the newer workspace signal says Phase 4,
+  50% complete, with no blockers—signal is the fresher progress observation;
+- its `.feature-workspaces/fix-l31-dogfood-secrets-001` tree is clean;
+- Git registers 29 worktrees: 2 under `.feature-workspaces`, 25 Claude-hosted, 1 Codex-hosted, plus the
+  main checkout. Only the one workspace above is present in active AEP state.
+
+Tracked skill bytes are copied into each worktree at its base commit. Merging a v3 re-pin while an old
+worker remains active therefore creates a temporary dual-version system: main agents read v3 while that
+worktree continues to read v2.5. The state schema permits it, but prompt/reference behavior differs and
+the active story already has a missing module definition and a missing dispatch-lock update in product
+context. The latter is the class of prose-ordering drift that v2.7/v3's lock-before-workspace invariant
+is designed to prevent, but it cannot retroactively repair this launch. This is avoidable risk.
+
+**Cutover gate:** finish, merge, and wrap `FIX-L31-DOGFOOD-SECRETS-001` with the currently pinned v2.5
+workflow; verify its main product-context story is terminal, `autopilot-state.json.workspaces` is empty,
+and no tick is locked; stop further dispatch; then merge the re-pin PR. Inventory the other registered
+worktrees before any later resume or deletion—do not prune them blindly.
+
+## Scratch-clone upgrade rehearsal
+
+The rehearsal cloned looplia's tracked HEAD, leaving the real repo and its untracked files untouched.
+
+Steps executed:
+
+1. Install `memorysaver/agentic-engineering-patterns@v3.0.0` for Codex (`-a codex --skill '*' -y`).
+2. Install the same tag for Claude Code (`-a claude-code --skill '*' -y`).
+3. Run the installed v3 scaffold audit; it correctly reported category A drift because the Claude install
+   replaced sharing symlinks with real directories.
+4. Run the installed `aep-scaffold/scripts/converge.sh --category A`.
+5. Re-run audit and byte/data checks.
+
+Results:
+
+- both installs discovered and installed **22/22** v3 skills;
+- post-converge `.agents` and `.claude` each expose 22 AEP skills, with all Claude entries symlinking to
+  the same real files;
+- all 168 files across the 22 installed v3 skill packages match tag `v3.0.0` in file set, content, and
+  executable mode;
+- post-converge v3 scaffold audit exits 0 across canonical layout, BDD e2e shape, and infrastructure;
+- all 34 product/calibration YAML files still parse;
+- `git diff -- product-context.yaml design-context.yaml product calibration` is empty.
+
+Two expected/manual issues remain:
+
+1. `AGENTS.md` still says v2.5.0 because the pin note is intentionally hand-owned.
+2. The skills CLI adds `aep-design-lens` but does not remove the stale, non-installed
+   `aep-testing-guide` lock entry. `npx skills remove aep-testing-guide -y` cannot match it. The upgrade PR
+   should delete that one stale lock object explicitly and verify the physical AEP set remains 22.
+
+## Recommended re-pin plan
+
+### Gate 0 — reach a clean lifecycle boundary
+
+1. Let `FIX-L31-DOGFOOD-SECRETS-001` finish under v2.5.0.
+2. Merge and `/aep-wrap` it.
+3. Confirm the story is terminal in main product context, the autopilot workspace map is empty, and no
+   tick is in progress. Do not accept runtime-state-only completion.
+4. Stop new dispatch before creating the re-pin PR.
+5. Review all 29 registered worktrees; mark stale ones for a separate, human-confirmed cleanup.
+
+### Gate 1 — create an isolated upgrade PR
+
+Run the documented two installs at `@v3.0.0`, once for Codex and once for Claude Code. Then:
+
+1. run v3 `/aep-scaffold` existing-project audit;
+2. confirm category A and run its converge script;
+3. remove the stale `aep-testing-guide` object from `skills-lock.json`;
+4. update the `AGENTS.md` pin note to `v3.0.0`;
+5. commit installed bytes, lockfile, symlinks, and the pin note together with hooks bypassed as documented
+   in the [upgrade guide](../../README.md#upgrading-to-a-new-release).
+
+Do not change `product-context.yaml`, `product/`, `calibration/`, or `.dev-workflow/autopilot-state.json`
+as part of the re-pin.
+
+### Gate 2 — deterministic verification
+
+Require all of the following in the upgrade PR:
+
+- `npx skills list` shows the 22 physical AEP v3 skills and no `aep-testing-guide`;
+- v3 scaffold audit exits 0;
+- `.claude/skills/aep-*` all resolve to `.agents/skills/aep-*`;
+- all product/calibration YAML parses with `npx js-yaml`;
+- product/context/calibration diff is empty;
+- the looplia project test/check suite is unchanged and green;
+- `AGENTS.md` names v3.0.0 and the installed package bytes match tag `v3.0.0`.
+
+### Gate 3 — behavior canary
+
+Because the available routing evidence is v3-only, use fresh sessions and record selected skill, loaded
+references, writes attempted, and postcondition for these boundary prompts before enabling unattended
+execution:
+
+| Prompt intent                                         | Expected v3 route |
+| ----------------------------------------------------- | ----------------- |
+| Install/explain AEP to a new contributor              | `aep-onboard`     |
+| Repair the existing project's skill layout            | `aep-scaffold`    |
+| Pick exactly one next story                           | `aep-dispatch`    |
+| Run the layer continuously unattended                 | `aep-autopilot`   |
+| Review usability/accessibility against theory         | `aep-design-lens` |
+| Capture the owner's visual taste                      | `aep-calibrate`   |
+| Validate looplia product context without implementing | `aep-validate`    |
+| Define a reusable evaluator contract                  | `aep-gen-eval`    |
+
+Also run a read-only next-story/context-assembly rehearsal. After the Layer 31 gate passes, it must
+resolve Split mode, use the Layer 32 active queue, load only the selected story/module/dependency
+context, and make no product-context write.
+Track the known protocol-spec false positives separately rather than “fixing” canonical looplia fields to
+the stale validator prose.
+
+### Gate 4 — bounded rollout
+
+After merge, start new agent sessions so frontmatter routing metadata is reloaded. Run the first one or two
+stories interactively or with explicit observation before restoring unattended autopilot. Verify:
+
+- selected skill and loaded references match the canary expectation;
+- no stale host worktree is adopted accidentally;
+- first v3 wrap writes convergence data before archive and remains idempotent;
+- layer completion distillation is proposal-only and does not edit skills;
+- token reduction is realized without omitted context in evaluator/dispatch briefs.
+
+## Final risk register
+
+| Severity         | Finding                                                                                           | Upgrade-caused?                      | Disposition                                                               |
+| ---------------- | ------------------------------------------------------------------------------------------------- | ------------------------------------ | ------------------------------------------------------------------------- |
+| High (temporary) | One v2.5 workspace is active while v3 cutover is being considered                                 | No                                   | Finish/merge/wrap before re-pin merge.                                    |
+| High (temporary) | Product context says the running story is pending/unassigned while state + signal say in progress | No; current v2.5 control-plane drift | Require terminal product state plus empty workspace state before cutover. |
+| Medium           | No same-model v2.5-v3 runtime A/B; v3 changes routing metadata and disclosure shape               | Yes, by design                       | Run the boundary canary and first-story observation.                      |
+| Medium           | Protocol checker prose conflicts with canonical story/layer-gate schema                           | No; present in v2.5                  | Fix upstream; use canonical template/scoring as authority meanwhile.      |
+| Medium           | Active recovery story module `e2e-verification` is absent from architecture modules               | No                                   | Complete it before cutover; do not redispatch it under v3.                |
+| Medium           | 29 registered worktrees can retain old pinned bytes if resumed                                    | No                                   | Inventory; clean only with explicit human confirmation.                   |
+| Low              | Stale `aep-testing-guide` lock entry survives CLI re-pin                                          | No                                   | Remove the lock object manually in the re-pin PR.                         |
+| Low              | `AGENTS.md` pin note is not auto-updated                                                          | Expected                             | Update it in the same PR.                                                 |
+
+## Conclusion
+
+No evidence requires a product-context migration or blocks looplia from adopting AEP v3.0.0. The data
+plane is compatible and the installation rehearsal succeeds. The residual uncertainty is in model
+selection/execution behavior, not file readability: v3 intentionally changes routing metadata, adds
+design-lens and convergence behaviors, and relies more heavily on progressive disclosure. A terminal-
+boundary re-pin, explicit canary, and bounded first-story rollout reduce that uncertainty without
+rewriting looplia's accumulated product context.

--- a/docs/decisions/verification-economics.md
+++ b/docs/decisions/verification-economics.md
@@ -221,12 +221,19 @@ between planning and merge:
   `files_affected`, `module`, contract obligations, `complexity`, `on_critical_path`, layer kind —
   into the machine-assembled brief. This prices the build (evaluator effort, dogfood scope) but is a
   _prediction_: `files_affected` is authored by the planning pipeline, not observed.
-- **Binding (merge boundary):** re-derived from the **actual diff** (`git diff --name-only
-"$BASE"...HEAD` — genuinely world-derived) against the human-owned sensitive-path list. If the
-  diff leaves the declared scope (`diff ∖ files_affected ≠ ∅`), the tier is recomputed from the diff
-  and `scope_drift: true` is recorded. **At binding, a tier may only go up, never down** — a story
-  cannot talk its way into a cheaper class by under-declaring scope, and impacted-journey selection
-  (§ Design 4) keys off the merged diff, never the declaration.
+- **Binding (Phase 5 entry):** re-derived from the **actual diff** (`git diff --name-only
+"$BASE"...HEAD` — genuinely world-derived, and it exists as soon as Phase 4 implementation
+  commits land) against the human-owned sensitive-path list. The binding derivation must run
+  **before the first evaluation round consumes the cap** — binding at the merge step would let the
+  whole eval loop run on the gameable provisional tier. If the diff leaves the declared scope
+  (`diff ∖ files_affected ≠ ∅`), the tier is recomputed from the diff and `scope_drift: true` is
+  recorded. **At binding, a tier may only go up, never down** — a story cannot talk its way into a
+  cheaper class by under-declaring scope, and impacted-journey selection (§ Design 4) keys off the
+  merged diff, never the declaration. **Pre-merge re-check (Phase 12):** commits added after the
+  last PASS (Phase 11 review fixes, Phase 11.5 human-eval fixes) re-run the derivation; a
+  post-eval drift into `sensitive_paths` upgrades the tier and requires one fresh evaluation round
+  at the new tier — this rides the existing stale-eval rule (`tick-protocol.md:237`, "code has
+  changed since your last evaluation"), it does not add a new mechanism.
 
 **The derivation function** (deterministic; ties resolve upward):
 
@@ -245,6 +252,31 @@ between planning and merge:
 | **standard** (default) | **2** — one decisive fix-and-reverify cycle | session default   | impacted-surface journey + canary | focused; full once at land    |
 | **deep**               | up to 5 + full recovery ladder              | highest available | full journey + prior-layer replay | full pre-eval **and** at land |
 
+**How the tier travels the trigger path.** Gen-eval is not self-triggering — it is configured down
+the chain autopilot → dispatch → launch → build, and the tier must ride that exact chain or it
+governs nothing:
+
+- **Dispatch** computes the provisional tier into the machine-assembled brief (grouped changes —
+  `compile_mode: grouped_change`, one workspace for N stories — take the **max** of member tiers;
+  Dynamic Workflow batches, which bypass `/aep-launch` entirely, carry the tier in the STEP-0 brief
+  and apply it to the workflow's verify stage, the evaluator of that mode).
+- **Launch is the tier's first real consumer**: today evaluator _existence_ is launch's full/light
+  call ("offer one when the change is full mode", `launch/SKILL.md:199-205`) and the criteria file
+  it writes (`.dev-workflow/evaluator-criteria.md`) is what makes build Phase 5 spawn an evaluator
+  at all. Under this design that decision becomes tier-derived and mechanical: `light` → no
+  criteria file (build self-reviews); `standard` → criteria from the scoring-framework presets;
+  `deep` → tailored criteria + the highest-available evaluator effort (the effort hint travels to
+  `executor.spawn_evaluator()`'s recipes). This also fixes the autonomous gap — the criteria
+  brainstorm is interactive today, and autopilot launches had no rule for it.
+- **The workspace publishes the tier**: `status.json` gains `verification_tier`, `tier_escalated`,
+  and the latest FAIL's `failure_class` (the signals spec is the schema owner), because that signal
+  file is the **only** thing autopilot may read.
+- **Autopilot's monitoring goes tier-aware**: the ④b nudge texts currently say "spawn the
+  evaluator" unconditionally and the escalation rule waits for a 5-round ladder — under tiers, the
+  nudge must match the workspace's published tier (a `light` workspace is nudged to self-review,
+  not to spawn), and `eval_not_converging` fires only after the published tier's cap **plus** the
+  automatic `standard → deep` escalation have both been spent.
+
 - **Cap exhaustion is defined, not silent:** when `standard` exhausts its 2 rounds on a genuine
   `product-defect`, the story **auto-escalates once to `deep`** (recorded as `tier_escalated: true`
   in the execution record — which is itself calibration data) and continues the ladder from where it
@@ -256,7 +288,10 @@ between planning and merge:
 - **Light-mode subsumption:** the design-time Light mode's eval-loop behavior
   (`design/references/workflow-modes.md`) is subsumed — Light mode selects `verification_tier:
 light` instead of carrying its own eval-loop toggle, collapsing the repo's three near-identical
-  "light" senses into one glossary-defined term.
+  "light" senses into one glossary-defined term. The same reconciliation absorbs launch's
+  full/light evaluator-offer criteria ("3+ tasks, UI-heavy, or security-sensitive → full",
+  `launch/SKILL.md:203`): those heuristics become **inputs to the provisional derivation** at
+  dispatch, not a second, independently-consulted depth switch.
 - **Threshold semantics (all tiers):** PASS means **zero blocking findings** against the
   hard-failure thresholds (`gen-eval/references/scoring-framework.md:107`). A perfect aggregate
   score is **never** a gate condition — perfect-score gates train evaluator-gaming and block
@@ -272,7 +307,7 @@ field is nullable and carries a named gather source (the gather stays best-effor
 
 ```yaml
 verification:
-  tier: light | standard | deep # from the brief; binding re-derivation wins
+  tier: light | standard | deep # provisional from the brief; Phase 5 binding re-derivation wins
   tier_escalated: true | false # cap-exhaustion escalation fired
   scope_drift: true | false # binding diff left the declared files_affected
   eval_rounds: <n> | null # from signals/eval-response-*.md count
@@ -376,10 +411,12 @@ no new required schema fields:**
    worked examples. It lives under gen-eval because gen-eval already owns evaluation canon and is
    read by `/aep-build`, `/aep-validate`, and `/aep-launch`; every other change site cross-references
    it **by name**.
-2. **`skills/patterns/executor/references/dogfood-validation.md`** — Unified report format
-   (`:160-199`): the required `**Failure-Class:**` line + the four-way routing table. Config block
-   (`:203-232`): a cross-reference stating `live_policy` lives in the e2e skill's `policy.md`, not
-   in `topology.routing.dogfood`.
+2. **`skills/patterns/executor/references/`** — `dogfood-validation.md`: Unified report format
+   (`:160-199`) gains the required `**Failure-Class:**` line + the four-way routing table; Config
+   block (`:203-232`) gains a cross-reference stating `live_policy` lives in the e2e skill's
+   `policy.md`, not in `topology.routing.dogfood`. `backends.md`: the `executor.spawn_evaluator()`
+   recipes accept an optional evaluator-effort hint derived from the tier (`deep` → highest
+   available).
 3. **`skills/project-setup/e2e-skill-scaffolding/`** — `templates/policy.md.tmpl` + SKILL.md Phase 2
    confirmation questions gain the `live_policy` decision, the `sensitive_paths` list, and the
    preflight probe sets (deploy-independent vs target-bound, with web **and** cli/tui probe
@@ -387,24 +424,36 @@ no new required schema fields:**
    `templates/tool-selection.md.tmpl` notes REFUSED vs SKIP semantics;
    `references/layer-gate-loop.md` and `references/three-tier-model.md` add the preflight gate, the
    evidence-class requirement on `passed`, and the replay-placement note.
-4. **`skills/agentic-development-workflow/build/SKILL.md`** — Phase 5 (`:126-145`): tier-capped
-   rounds, the taxonomy check at every FAIL, cap-exhaustion auto-escalation. Phase 6 Step B
-   (`:192-215`): deploy-independent preflight on every story; target-bound preflight when execution
-   runs here. Phase 8 (`:237`): impacted-only replay + canary + the `deep` exception.
+4. **`skills/agentic-development-workflow/build/SKILL.md`** — Phase 5 (`:126-145`): the **binding
+   tier re-derivation at Phase 5 entry** (before any round spends the cap), tier-capped rounds, the
+   taxonomy check at every FAIL, cap-exhaustion auto-escalation, and publishing
+   `verification_tier` / `tier_escalated` to `status.json`. Phase 6 Step B (`:192-215`):
+   deploy-independent preflight on every story; target-bound preflight when execution runs here.
+   Phase 8 (`:237`): impacted-only replay + canary + the `deep` exception. Phase 12: the tier
+   re-check on post-eval commits (sensitive-path drift ⇒ one fresh round at the upgraded tier).
 5. **`skills/patterns/gen-eval/references/`** — `eval-protocol.md` (`:116`): tier-derived
    `max_rounds`; evaluator-authored `failure_class` in the response format; per-round response
    persistence. `recovery-ladder.md` (`:3`, `:25-31`, `:59-67`): the second `max_rounds` copy; rungs
    re-keyed relative to the tier cap; "When to Skip the Ladder" reframed as the typed taxonomy step
    with the class mapping. `scoring-framework.md`: zero-blocking threshold semantics; perfect-score
    gates named as an anti-pattern.
-6. **`skills/agentic-development-workflow/launch/references/evaluator.md`** (`:73-74`) — the third
-   `max_rounds` copy goes tier-derived.
+6. **`skills/agentic-development-workflow/launch/`** — `SKILL.md` "Optional: Evaluator (Full
+   Mode)" (`:199-205`): evaluator existence, criteria, and effort become **tier-derived from the
+   dispatch brief** (light → no criteria file; standard → preset criteria; deep → tailored criteria
+   - top effort) — this replaces the workflow-modes full/light heuristics as launch's decision
+     rule and gives autonomous launches a deterministic criteria policy.
+     `references/evaluator.md` (`:73-74`): the third `max_rounds` copy goes tier-derived; the
+     criteria-brainstorm step notes the autonomous fallback per tier.
+     `references/signals-spec.md`: `status.json` gains `verification_tier`, `tier_escalated`, and
+     latest-FAIL `failure_class` — the fields autopilot's tier-aware monitoring reads.
 7. **`skills/agentic-development-workflow/wrap/references/`** — `convergence.md` (`:70-88`): the
    `verification:` block. `layer-advance.md`: full replay + mid-layer checkpoint policy + budget box
    - evidence-class check before flipping `passed`.
 8. **`skills/product-context/dispatch/`** — `references/context-assembly.md` (the assembly-time
-   home): provisional tier derivation into the machine-assembled brief; `SKILL.md` (`:237`) notes
-   the binding re-derivation at the merge boundary.
+   home): provisional tier derivation into the machine-assembled brief (grouped changes take the
+   max of member tiers); `SKILL.md` (`:237`) notes the binding re-derivation contract (Phase 5
+   entry, build-owned). `references/workflow-mode.md`: the STEP-0 brief carries the tier; the
+   workflow verify stage — that mode's evaluator — honors the tier cap.
 9. **`skills/product-context/_shared/references/telemetry-ingestion.md`** (regenerated into
    `reflect/` and `watch/` via `build-skills.sh`) — the `dogfood_report` adapter parses
    `**Failure-Class:**`; `environment` / `harness-flake` / `scope` findings **never auto-file**
@@ -412,10 +461,14 @@ no new required schema fields:**
 10. **`skills/patterns/autopilot/`** — `references/tick-protocol.md`: REFUSED ≠ FAIL at the gate (a
     refused gate pauses cheaply with the ops checklist and **re-probes world-derived on each tick**,
     so human repair auto-resumes; remaining in-layer stories may still dispatch);
-    "`eval_not_converging` after the ladder is exhausted" becomes tier-derived.
-    `references/state-schema.md` (`:138`): a new `environment_repair` escalation type carrying the
-    checklist. `references/post-merge-guard.md`: preflight before the guard's dogfood;
-    `Failure-Class:` in the guard report; `live_policy` governs the guard's live half.
+    "`eval_not_converging` after the ladder is exhausted" becomes tier-derived (fires only after
+    the published cap **plus** the automatic `standard → deep` escalation are spent); the ④b nudge
+    texts (`:212`, `:237`) go tier-aware — read `verification_tier` from `status.json`, nudge a
+    `light` workspace to self-review rather than "spawn the evaluator", and extend the stale-eval
+    nudge with the sensitive-path-drift upgrade. `references/state-schema.md` (`:138`): a new
+    `environment_repair` escalation type carrying the checklist.
+    `references/post-merge-guard.md`: preflight before the guard's dogfood; `Failure-Class:` in the
+    guard report; `live_policy` governs the guard's live half.
 11. **`skills/agentic-development-workflow/design/references/workflow-modes.md`** — Light mode's
     eval-loop behavior subsumed into `verification_tier: light`.
 12. **`docs/glossary.md`** — new entries: **Verification Tier**, **Failure Class (Failure
@@ -447,10 +500,10 @@ no new required schema fields:**
 | `/aep-gen-eval`  | Owns the verification-economics reference; tier-derived caps; evaluator-authored `failure_class`; zero-blocking semantics |
 | `/aep-build`     | Preflight before dogfood; taxonomy check before any ladder rung; impacted replay + canary; cap-exhaustion escalation      |
 | `/aep-wrap`      | Full replay + checkpoints + budget box + evidence-class check at the gate; gathers the `verification:` block              |
-| `/aep-dispatch`  | Provisional tier into the machine-assembled brief; binding re-derivation contract at the merge boundary                   |
+| `/aep-dispatch`  | Provisional tier into the machine-assembled brief (grouped = max; workflow mode carries it in STEP-0)                     |
 | `/aep-reflect`   | Routes on `failure_class`; ratifies `harness-flake`; ingests escape rate; proposes dampened calibration                   |
-| `/aep-autopilot` | REFUSED ≠ FAIL tick handling; `environment_repair` escalation; preflight + `live_policy` on the post-merge guard          |
-| `/aep-launch`    | Evaluator round cap read from the tier                                                                                    |
+| `/aep-autopilot` | REFUSED ≠ FAIL ticks; tier-aware ④b nudges + escalation; `environment_repair`; preflight + `live_policy` on the guard     |
+| `/aep-launch`    | Evaluator existence + criteria + effort derived from the tier; signals spec carries the tier fields                       |
 | e2e scaffold     | `live_policy` + `sensitive_paths` + probe sets in `policy.md`; budget box in the gate evidence template                   |
 
 ## Migration

--- a/docs/decisions/verification-economics.md
+++ b/docs/decisions/verification-economics.md
@@ -14,7 +14,10 @@ judging content stays judgment.
 
 > **Status:** Proposal (not yet implemented). This document records the design precisely so the
 > implementation PRs (target: v3.1.0) can be made and reviewed against it. It changes how AEP works,
-> so it lives in `decisions/` per the [docs routing guide](../README.md).
+> so it lives in `decisions/` per the [docs routing guide](../README.md). Revised after a three-lens
+> design review (factual grounding, adversarial critique, downstream operability); the review's
+> blocking findings are folded in below — classification authority, two-point tier derivation,
+> cap-exhaustion semantics, autopilot integration, and the `live_policy`-aware preflight.
 
 > **Sourcing note:** Sourced from the 2026-07-16 cross-repo research session over SIBYL (story
 > SIBYL-189, `openspec/changes/archive/2026-07-15-SIBYL-189/`, and
@@ -36,13 +39,16 @@ Both v2.5.0 consumers now spend the majority of their loop on verification and p
 - **looplia:** of the last 100 commits, **16 are feature-bearing PR merges; 84 are
   dispatch/design/prove/complete/archive/lessons overhead** (≈1:5.3). Layer 31's 14 stories all
   merged within three days — then the layer halted at autopilot tick 444 with **zero further product
-  advance**: the mandatory post-deploy production dogfood failed on a **pure environment
-  precondition** (prod secrets absent from CI, Wrangler OAuth bound to the wrong Cloudflare account).
-  The loop's only failure path routed this ops problem into **two code-fix recovery stories**, each of
-  which exhausted **all five** independent evaluation rounds and still failed (final rounds 2.79 and
-  3.28 of 5), pausing the loop for human redesign. Ten evaluation rounds were spent repairing a
-  problem no code change could fix. Verification cost is uninstrumented there
-  (`stats.total_cost_usd: 0` after 444 ticks).
+  advance**: the mandatory post-deploy production dogfood failed on an **environment
+  precondition** (prod secrets absent from CI, Wrangler OAuth bound to the wrong Cloudflare
+  account). The loop's only failure path routed this ops problem into **two code-fix recovery
+  stories**, each of which exhausted **all five** independent evaluation rounds and still failed
+  (final rounds 2.79 and 3.28 of 5), pausing the loop for human redesign. Ten evaluation rounds were
+  spent repairing a problem no evaluation round could fix. (The incident also carried a genuine
+  product component — a tracked literal-password fallback in four dogfood scripts, and deploy config
+  that never wired the fixture binding — which is exactly why the taxonomy below is per-finding, not
+  per-incident.) Verification cost is uninstrumented there (`stats.total_cost_usd: 0` after 444
+  ticks).
 - **looplia's merge gate is a perfect-score gate:** a lesson (`l31-014`) ratcheted the threshold to
   _"the independent evaluator must return exactly 5.00/5.00 with zero findings before PR/merge."_
   Upstream AEP requires only "no blocking findings remaining"
@@ -61,8 +67,8 @@ Both v2.5.0 consumers now spend the majority of their loop on verification and p
 Four structural defects explain the numbers:
 
 1. **Uniform depth.** Every story gets the maximal gauntlet regardless of blast radius. The only
-   knobs today are Light mode and `policy.md`'s tiers/target/timing — nothing prices _depth_ per
-   story.
+   knobs today are the design-time Light mode and `policy.md`'s tiers/target/timing — nothing prices
+   _depth_ per story.
 2. **Missing failure taxonomy.** The dogfood report carries severity and category
    (`executor/references/dogfood-validation.md:160-199`) but not _failure class_ — so an environment
    failure, a harness flake, and a product defect all route into the same story-filing → gen-eval →
@@ -90,13 +96,13 @@ reward-hacking future model — satisfy the check without satisfying the intent?
 > **Cheap and tamper-evident validators run in the inner loop, always. Expensive or gameable
 > validators run at the outermost boundary that still catches their failure class, gated by risk.**
 
-| DevOps position                  | Validators                                                                                              | Properties                                            | Frequency                 |
-| -------------------------------- | ------------------------------------------------------------------------------------------------------- | ----------------------------------------------------- | ------------------------- |
-| **Inner loop** (per task/commit) | Typed gates: lint, typecheck, focused Tier-1, schema validation, scope gates, **environment preflight** | Deterministic, named refusals, cannot be rationalized | Every commit              |
-| **Merge boundary** (per story)   | **One** independent evaluator round (diff vs. acceptance contract) + CI + Tier-3 drivers                | Expensive, partially gameable → risk-tiered rounds    | Once per story by default |
-| **Deploy boundary** (per layer)  | Tier-2 journey dogfood on the real target, **full regression replay**, coverage matrices, gate evidence | Expensive but tamper-evident (real execution)         | Once per layer            |
-| **Operate** (post-deploy)        | Telemetry / production outcomes → `/aep-watch` → `/aep-reflect`                                         | The least gameable evidence that exists               | Continuous                |
-| **Human gate**                   | Residual-risk acceptance at layer advance; taxonomy escalations                                         | Most expensive                                        | Per layer + exceptions    |
+| DevOps position                  | Validators                                                                                              | Properties                                            | Frequency                       |
+| -------------------------------- | ------------------------------------------------------------------------------------------------------- | ----------------------------------------------------- | ------------------------------- |
+| **Inner loop** (per task/commit) | Typed gates: lint, typecheck, focused Tier-1, schema validation, scope gates, **environment preflight** | Deterministic, named refusals, cannot be rationalized | Every commit                    |
+| **Merge boundary** (per story)   | One decisive evaluator cycle (diff vs. acceptance contract; tier-capped rounds) + CI + Tier-3 drivers   | Expensive, partially gameable → risk-tiered rounds    | Once per story under `standard` |
+| **Deploy boundary** (per layer)  | Tier-2 journey dogfood on the real target, **full regression replay**, coverage matrices, gate evidence | Expensive but tamper-evident (real execution)         | Once per layer                  |
+| **Operate** (post-deploy)        | Telemetry / production outcomes → `/aep-watch` → `/aep-reflect`                                         | The least gameable evidence that exists               | Continuous                      |
+| **Human gate**                   | Residual-risk acceptance at layer advance; taxonomy escalations                                         | Most expensive                                        | Per layer + exceptions          |
 
 Two consequences worth naming:
 
@@ -106,8 +112,9 @@ Two consequences worth naming:
   why rounds must be fewer and more decisive, not more numerous.
 - **A verifier must not share incentives with the generator.** AEP already separates
   generator/evaluator (`gen-eval/SKILL.md`) and makes `/aep-wrap` execute-never-author journeys. This
-  proposal extends the same separation to _evidence_: a gate flip requires at least one evidence
-  class the generator cannot modify (§ Design 5).
+  proposal extends the same separation to _evidence_ (§ Design 5) and to _classification authority_
+  (§ Design 1): any label that reduces verification spend must come from a non-generator role or
+  from world-derivable evidence.
 
 ---
 
@@ -115,61 +122,141 @@ Two consequences worth naming:
 
 ### 1. Failure taxonomy — typed, evaluated before any repair spend
 
-Every FAIL from any tier acquires a **`failure_class`**:
+Every FAIL from any tier acquires a **`failure_class`**, assigned **per finding** (one incident may
+carry findings of different classes):
 
 ```
 failure_class: product-defect | environment | harness-flake | scope
 ```
 
 - **`product-defect`** — the built thing is wrong. Routes to the existing path: finding → story /
-  fix commit → gen-eval.
+  fix commit → gen-eval. **Security-critical product defects keep their existing immediate
+  escalation** (`recovery-ladder.md:63`): they are `product-defect`, and they skip the ladder to a
+  human on the first FAIL — the taxonomy adds routing, it never removes an escalation.
 - **`environment`** — a precondition outside the worktree is unmet (secrets, credentials, wrong
   account, target unreachable, quota exhausted). Routes to an **ops checklist surfaced to the
-  human/orchestrator. Never files a code story; never enters the recovery ladder; never spends an
-  evaluation round.** The gate stays refused with a named tag until the environment is repaired,
-  then re-runs.
+  human/orchestrator. Never auto-files a code story; never enters the recovery ladder; never spends
+  an evaluation round.** The gate stays refused with a named tag until the environment is repaired,
+  then re-runs. The checklist may _recommend_ human-filed hardening stories through the normal path.
+  **Exception — unmet in-repo dependencies** (an unmerged story, an unbuilt sibling module) are a
+  sequencing problem: they route to `/aep-dispatch` re-ordering, not to the ops checklist.
 - **`harness-flake`** — the test machinery itself misbehaved (race, port collision, known-red
   baseline). Routes to quarantine + a harness story; the product gate re-runs after quarantine.
-- **`scope`** — the acceptance criterion itself is wrong or the story is mis-sliced. Routes to
+- **`scope`** — the acceptance criterion itself is wrong, the story is mis-sliced, or the spec is
+  internally contradictory (the ladder's existing "spec contradiction" skip maps here). Routes to
   `/aep-reflect` re-slicing, not to repair rounds.
 
-Two mechanical carriers make the taxonomy typed rather than prose:
+**Classification authority — the tamper-resistance rule.** The routing above is only safe if the
+FAILing party cannot label its own failure into a cheaper class ("the test is flaky" is the
+canonical reward hack). Each spend-reducing class therefore has an **evidence requirement**, and
+anything without qualifying evidence defaults to `product-defect`:
 
-- **The unified dogfood report** (`executor/references/dogfood-validation.md` → Unified report
-  format) gains a required `**Failure-Class:**` line per finding; the `dogfood_report` adapter and
-  the `/aep-reflect` Step-2 classifier route on it.
-- **The environment preflight gate**: before any Tier-2/Tier-3 execution (build Phase 6 Step B, wrap
-  layer gate), a preflight probe checks the target's preconditions — required secrets present, auth
-  identity matches the expected account, target reachable, fixtures seedable — and **refuses with
-  named tags** (`REFUSING [dogfood-secret-absent:<NAME>]`, `REFUSING [auth-identity-mismatch:<got≠want>]`)
-  _before_ any journey spend. A refused preflight is `environment` by construction: zero scenarios
-  run, zero findings generated, zero rounds spent. The generated e2e skill's `policy.md` names the
-  preflight probes next to the target it already owns.
+| Class            | Claimable by                                                                                                                                                                                                           |
+| ---------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `environment`    | **Only** a named preflight/probe refusal tag (`REFUSING [dogfood-secret-absent:<NAME>]`). No tag → not environment.                                                                                                    |
+| `harness-flake`  | World-derivable reproduction evidence (a same-SHA re-run that passes with zero diff, or membership in an orchestrator-owned quarantine list), **ratified by wrap//aep-reflect — never self-applied by the generator**. |
+| `scope`          | A human acknowledgment on the `needs-human.md` gate record before the routing takes effect.                                                                                                                            |
+| `product-defect` | The default. Requires no evidence — it is the class that spends verification.                                                                                                                                          |
+
+**Ownership check (dual-class incidents).** When a refused precondition is created or managed by
+artifacts _in this repo_ (deploy config, IaC, wrangler bindings, seed scripts), the ops checklist is
+paired with a `product-defect` finding for the wiring — otherwise the ops path becomes a way to mask
+product defects behind hand-repair. looplia's secret incident is the worked case: the missing GitHub
+secret was `environment`; the deploy config that silently omitted the fixture binding and the
+tracked literal-password fallback were `product-defect` findings discovered by the same probe.
+
+**Typed carriers, per surface** (a taxonomy that lives only in prose is the drift class this repo
+already documented):
+
+- **Tier-2/3 dogfood and post-merge guard reports** — the unified report
+  (`executor/references/dogfood-validation.md` → Unified report format) gains a required
+  `**Failure-Class:**` line per finding; the `dogfood_report` adapter
+  (`_shared/references/telemetry-ingestion.md`) parses it and **never auto-files** `environment` /
+  `harness-flake` / `scope` findings.
+- **Phase 5 evaluation FAILs** — the **evaluator** (not the generator) writes `failure_class` into
+  `eval-response-<N>.md` / `feature-verification.json`, consistent with the existing field-ownership
+  rule ("the generator cannot mark its own work as passing", `eval-protocol.md:265`).
+- **Build/CI failures** — `status.json` failure logs gain `failure_class` alongside the existing
+  `error_class` enum (`product-context-schema.yaml:348`: `test_failure | timeout | context_overflow
+| merge_conflict`). `error_class` records execution mechanics and stays; `failure_class` is the
+  routing layer above it. Default mapping (overridable with evidence): `test_failure` →
+  `product-defect`; `timeout` / `context_overflow` → `harness-flake`; `merge_conflict` → sequencing
+  → `/aep-dispatch`.
+
+**The environment preflight gate.** Probes split into two sets, because half of looplia's L31
+failure was knowable before any merge:
+
+- **Deploy-independent probes** — required secret _names_ present in CI config, expected account
+  fingerprint recorded vs. actual auth identity, env-var names wired in deploy config. These run
+  **pre-merge in build Phase 6 Step B on every story, regardless of `journey_timing`** — they need
+  no live target.
+- **Target-bound probes** — target reachable, deployed bindings present, fixtures seedable. These
+  run wherever journey _execution_ runs: Phase 6 Step B under `journey_timing: pre-merge`; the
+  `/aep-wrap` layer gate (and the autopilot post-merge guard) under `post-deploy`. Under
+  `post-deploy` an environment refusal therefore surfaces post-merge **by design** — the win over
+  today is that it surfaces as a named, zero-spend refusal instead of ten evaluation rounds.
+
+A refusal names every unmet precondition (`REFUSING [dogfood-secret-absent:<NAME>]`,
+`REFUSING [auth-identity-mismatch:<got≠want>]`) _before_ any journey spend: zero scenarios run, zero
+findings generated, zero rounds spent — `environment` by construction. Probes are declared in the
+generated e2e skill's `policy.md` next to the target they guard, **derived per gate from
+`live_policy`** (§ Design 5): a gate probes only the preconditions of criteria it _requires_ — the
+optional live half of a non-milestone gate is not probed, and its absence stays **SKIP**, preserving
+the existing degrade semantics (`REFUSED` blocks only what the gate requires; `SKIP` = optional
+capability absent; `FAIL` = the product misbehaved). CLI/TUI projects get a non-vacuous probe
+vocabulary: provider auth present, provider reachable, PTY driver healthy, fixture repos creatable.
 
 The recovery ladder keeps its rungs, but the taxonomy check is promoted from a prose "When to Skip"
 bullet to a **mandatory step at every FAIL, before choosing a rung**: only `product-defect` climbs
-the ladder.
+the ladder, and the existing skip rules map onto classes (security → `product-defect` +
+immediate escalation; spec contradiction → `scope`; missing credential/access → `environment`;
+unbuilt in-repo dependency → dispatch re-ordering).
 
 ### 2. Risk-tiered verification depth
 
-Each story gets a **`verification_tier`** — **derived at dispatch time from observable facts, not
-hand-authored** (no new required schema field on stories; the tier is computed into the
-machine-assembled brief and recorded in the execution record):
+Each story gets a **`verification_tier`** — derived **twice**, because the honest inputs change
+between planning and merge:
 
-Inputs (all world-derivable at dispatch): number of architecture modules touched
-(`files_affected` overlap), whether an API contract / schema / migration is in scope, whether the
-diff touches security-sensitive paths (auth, payments, data deletion, secrets handling), novelty
-(new module vs. modification of a covered one), and layer kind (walking skeleton vs. enrichment).
+- **Provisional (dispatch time):** computed from the story's plan fields — declared
+  `files_affected`, `module`, contract obligations, `complexity`, `on_critical_path`, layer kind —
+  into the machine-assembled brief. This prices the build (evaluator effort, dogfood scope) but is a
+  _prediction_: `files_affected` is authored by the planning pipeline, not observed.
+- **Binding (merge boundary):** re-derived from the **actual diff** (`git diff --name-only
+"$BASE"...HEAD` — genuinely world-derived) against the human-owned sensitive-path list. If the
+  diff leaves the declared scope (`diff ∖ files_affected ≠ ∅`), the tier is recomputed from the diff
+  and `scope_drift: true` is recorded. **At binding, a tier may only go up, never down** — a story
+  cannot talk its way into a cheaper class by under-declaring scope, and impacted-journey selection
+  (§ Design 4) keys off the merged diff, never the declaration.
 
-| Tier                   | Evaluator rounds (cap)             | Evaluator effort  | Dogfood scope (Phase 6B)           | Full-suite runs               |
-| ---------------------- | ---------------------------------- | ----------------- | ---------------------------------- | ----------------------------- |
-| **light**              | 0 (generator self-review, lenient) | —                 | render smoke / none                | focused only                  |
-| **standard** (default) | **2**, taxonomy check each FAIL    | session default   | affected-surface journey scenarios | focused; full once at land    |
-| **deep**               | up to 5 + full recovery ladder     | highest available | full journey + prior-layer replay  | full pre-eval **and** at land |
+**The derivation function** (deterministic; ties resolve upward):
 
-- **Hard floor:** stories touching auth, payments, irreversible data operations, or migrations are
-  always `deep`, whatever the derivation says. The human can override any story's tier; overrides are
-  recorded.
+- **`deep`** iff any: the diff (or, provisionally, the plan) matches a **`sensitive_paths`** glob —
+  a human-owned list in the generated e2e skill's `policy.md` covering auth, payments, irreversible
+  data operations, migrations, deploy/CI config; **or** the layer is the walking skeleton (0/0.5);
+  **or** a human override says so. This is the hard floor; it is never loosenable by calibration.
+- **`light`** iff all: the change is docs/tests-only by path, no contract obligations, no new
+  non-test files — confirmed by the binding diff, not just the plan.
+- **`standard`** otherwise (the default; multi-module or `on_critical_path` stories are at least
+  `standard`).
+
+| Tier                   | Evaluator rounds (cap)                      | Evaluator effort  | Dogfood scope (Phase 6B)          | Full-suite runs               |
+| ---------------------- | ------------------------------------------- | ----------------- | --------------------------------- | ----------------------------- |
+| **light**              | 0 (generator self-review, lenient)          | —                 | render smoke / none               | focused only                  |
+| **standard** (default) | **2** — one decisive fix-and-reverify cycle | session default   | impacted-surface journey + canary | focused; full once at land    |
+| **deep**               | up to 5 + full recovery ladder              | highest available | full journey + prior-layer replay | full pre-eval **and** at land |
+
+- **Cap exhaustion is defined, not silent:** when `standard` exhausts its 2 rounds on a genuine
+  `product-defect`, the story **auto-escalates once to `deep`** (recorded as `tier_escalated: true`
+  in the execution record — which is itself calibration data) and continues the ladder from where it
+  left off; only after `deep`'s ladder exhausts does it reach the human gate. Ladder rungs re-key to
+  _position past the tier's cap_ rather than absolute round numbers 3–5.
+- **The layer gate's depth is owned by `/aep-wrap`, independent of any story's tier.** A `light`
+  integration story does not weaken the gate: full replay, coverage matrices, and evidence classes
+  run at the gate whatever the tiers of the stories inside the layer.
+- **Light-mode subsumption:** the design-time Light mode's eval-loop behavior
+  (`design/references/workflow-modes.md`) is subsumed — Light mode selects `verification_tier:
+light` instead of carrying its own eval-loop toggle, collapsing the repo's three near-identical
+  "light" senses into one glossary-defined term.
 - **Threshold semantics (all tiers):** PASS means **zero blocking findings** against the
   hard-failure thresholds (`gen-eval/references/scoring-framework.md:107`). A perfect aggregate
   score is **never** a gate condition — perfect-score gates train evaluator-gaming and block
@@ -180,55 +267,80 @@ diff touches security-sensitive paths (auth, payments, data deletion, secrets ha
 
 ### 3. Verification accounting — priced, recorded, calibrated
 
-`execution-record.yaml` (`wrap/references/convergence.md:70-88`) gains a `verification:` block,
-gathered best-effort like every other field:
+`execution-record.yaml` (`wrap/references/convergence.md:70-88`) gains a `verification:` block. Every
+field is nullable and carries a named gather source (the gather stays best-effort):
 
 ```yaml
 verification:
-  tier: light | standard | deep # as dispatched (+ `override: human` when overridden)
-  eval_rounds: <n>
-  findings_by_round: [<n>, ...] # blocking+important findings per round
-  suite_runs: <n>
-  suite_seconds: <n> | null
-  journey_scenarios_run: <n>
-  preflight_refusals: [] # named tags, if any
-  cost_usd: <n> | null # verification share when separable; else null
-  escaped_defects: [] # filled retroactively by /aep-reflect (see below)
+  tier: light | standard | deep # from the brief; binding re-derivation wins
+  tier_escalated: true | false # cap-exhaustion escalation fired
+  scope_drift: true | false # binding diff left the declared files_affected
+  eval_rounds: <n> | null # from signals/eval-response-*.md count
+  findings_by_round: [<n>, ...] | null # blocking+important per round; needs per-round persistence
+  journey_scenarios_run: <n> | null # from the dogfood report
+  preflight_refusals: [] # named tags, if any; [] when preflight passed
+  cost_usd: <n> | null # verification share when separable
+  escaped_defects: [] # filled retroactively by /aep-reflect
 ```
+
+Suite-level economics (`suite_runs`, `suite_seconds`) live in the **layer budget box** (the
+layer-gate evidence doc), where `/aep-wrap` actually runs the suites — not in the per-story record
+where they proved ungatherable downstream. **Per-round eval persistence** (keeping
+`eval-response-<N>.md` through wrap's gather) becomes an explicit requirement of the implementation:
+`findings_by_round` is the loosening signal the calibration loop depends on, and today only one
+consumer's workspaces retain it.
 
 Consumers close the loop:
 
 - **Escape-rate ingestion:** when `/aep-reflect` classifies a post-merge bug, it traces the bug to
-  the story that introduced it and appends to that story's `escaped_defects`. Escape rate (defects
-  that escaped ÷ verification rounds spent) is the calibration signal.
-- **Bidirectional calibration:** layer distillation (already proposal-only,
-  `wrap/references/convergence.md` §2) may propose tier-derivation adjustments **in both
-  directions** — tighten where defects escape, and **loosen or retire** where `findings_by_round`
-  shows round ≥2 catching nothing across a layer. Verification assets get a lifecycle: distillation
-  may propose merging or retiring journeys that have replayed green for N layers with no coverage
-  loss. Proposals only; a human applies them. This is what breaks the ratchet.
+  the story that introduced it and appends to that story's `escaped_defects`. Escape rate is defined
+  **per story per tier** (escapes ÷ stories at that tier — well-defined even for `light`'s zero
+  rounds). When attribution is ambiguous (multi-story interaction bugs), the escape attributes to
+  the **layer**, not to no one — ambiguous escapes must count somewhere.
+- **Bidirectional calibration, dampened.** Layer distillation (already proposal-only,
+  `wrap/references/convergence.md` §2) may propose tier-derivation adjustments in both directions —
+  but the two directions have asymmetric feedback latency (loosening feels good immediately;
+  escapes surface a layer later), which is the textbook oscillation setup. Dampening rules:
+  **loosening proposals require ≥2 layers of `findings_by_round` evidence and zero unresolved
+  escape attributions; loosen at most one notch per layer; the `sensitive_paths` hard floor is
+  never loosenable.** Tightening has no such damper. Verification assets get the same lifecycle:
+  distillation may propose merging or retiring journeys that have replayed green for N layers with
+  no coverage loss. Proposals only; a human applies them. This is what breaks the ratchet.
 - **The layer budget box:** each layer gate's evidence doc records expected vs. actual verification
-  spend (rounds, suite time, scenarios, `cost_usd` where known). When actuals overrun the box,
-  `/aep-wrap` surfaces a **scope-vs-verification tradeoff to the human** at the layer-advance gate —
-  the loop asks, it does not silently grind. (looplia's tick-444 halt is the degenerate form of this
-  question, asked 10 rounds too late.)
+  spend (rounds, suite runs/time, scenarios, `cost_usd` where known). **The expected values are
+  human-owned** — set at layer planning or accepted from a distillation proposal — never authored by
+  the loop that is graded against them. When actuals overrun the box, `/aep-wrap` surfaces a
+  **scope-vs-verification tradeoff to the human** at the layer-advance gate — the loop asks, it does
+  not silently grind. (looplia's tick-444 halt is the degenerate form of this question, asked ten
+  rounds too late.)
 
 ### 4. Regression replay moves from story to layer granularity
 
-- **Per story** (`/aep-build` Phase 8, `build/SKILL.md:237`): replay only **impacted** journeys —
-  those whose `covers:` criteria or module mapping intersects the story's `files_affected`. The
-  journey front-matter (`layer:`, `covers:`) already makes impact selection expressible.
+- **Per story** (`/aep-build` Phase 8, `build/SKILL.md:237`): replay the **impacted** journey set —
+  selected against the **merged diff** (never the declared `files_affected`): a journey is impacted
+  when its `covers:` criteria belong to the story, when its optional `paths:` front-matter globs
+  intersect the diff, or when it declares no `paths:` at all (fail-open: undeclared journeys stay in
+  the replay set). **Plus, always, the walking-skeleton journey as a canary** — one execution that
+  catches the "the app no longer starts" class immediately. `deep`-tier stories replay the full
+  prior-layer set per story (the one exception to impacted-only).
 - **Per layer** (`/aep-wrap` layer gate, `wrap/references/layer-advance.md`): the **full**
-  prior-layer replay stays here, once per layer — this is where cumulative regression belongs, and
-  it keeps the guarantee `/aep-dispatch` relies on (a layer cannot advance past a broken past).
-- Total journey executions drop from O(layers × stories) to O(stories + layers).
+  prior-layer replay stays here, once per layer. For large layers, a **mid-layer full-replay
+  checkpoint every k stories** (k chosen at layer planning; looplia's L31 had 14 stories — k=5
+  would have bounded defect lifetime to 5 merges) keeps gate-time bisects tractable.
+- **The honest tradeoff:** executions drop from O(layers × stories) to O(stories + layers), but a
+  cross-cutting regression a story's diff does not intersect now lives until the next checkpoint or
+  the gate — worst-case defect lifetime is k merges, and gate-time attribution costs a bisect. The
+  canary, the fail-open selection rule, and the checkpoint are the price paid to bound that
+  latency; layers that cannot tolerate it (or stories at `deep`) keep full replay.
 
 ### 5. Tamper-evident evidence classes on every gate
 
 A layer gate may flip to `passed` only when its evidence includes **at least one class the
 generator cannot modify**:
 
-1. a CI run bound to the merged SHA;
+1. a CI run bound to the merged SHA — **valid as tamper-evident only when the workflow definitions
+   are outside the story's diff scope** (a diff touching `.github/workflows/**` triggers a scope
+   refusal or human review; a generator that edits its own referee is not evidence);
 2. journey execution performed by `/aep-wrap` (executes-never-authors — existing canon);
 3. **read-only golden fixtures with a ledger-equality oracle** — fixture trees the generator's
    workspace cannot write, verified by before/after equality of durable state (SIBYL's
@@ -243,11 +355,12 @@ Additionally:
   the evaluator's context (criteria file, contract file, diff range), so the generator cannot curate
   what its judge sees.
 - **`policy.md` gains a `live_policy` decision** for cost-bearing dogfoods (live model calls, quota-
-  or fee-metered targets): `every_gate | milestone_gates | none`, with the milestone list named in
-  the policy. Non-milestone gates use zero-cost render smokes / scripted tiers. This upstreams
-  SIBYL's proven `live_policy: milestone_gates_only` pattern. The existing SKIP-not-FAIL degrade
-  semantics stay; the taxonomy separates SKIP (tool absent), REFUSED (environment), and FAIL
-  (product) so none masquerades as another.
+  or fee-metered targets): `every_gate | milestone_gates_only | none`, with the milestone list named
+  in the policy — the value set matches the proven downstream shape (SIBYL's
+  `live_policy: milestone_gates_only`, which moves from `topology.routing.dogfood` to `policy.md` on
+  re-pin; `policy.md` already canonically owns tiers/target/timing). Non-milestone gates use
+  zero-cost render smokes / scripted tiers, and — per § Design 1 — their preflight does not probe
+  the optional live half, whose absence stays SKIP.
 
 ---
 
@@ -257,44 +370,63 @@ Additionally:
 no new required schema fields:**
 
 1. **NEW `skills/patterns/gen-eval/references/verification-economics.md`** — the canonical reference
-   carrying the placement matrix, the failure taxonomy + routing table, the tier presets +
-   derivation inputs, the `verification:` accounting schema, the evidence-class catalog, and the
+   carrying the placement matrix, the failure taxonomy + classification-authority table + routing,
+   the `error_class` → `failure_class` mapping, the tier derivation function + two-point protocol,
+   the `verification:` accounting schema with gather sources, the evidence-class catalog, and the
    worked examples. It lives under gen-eval because gen-eval already owns evaluation canon and is
-   read by `/aep-build`, `/aep-validate`, and `/aep-launch`; build, wrap, dispatch, reflect, and the
-   e2e scaffold cross-reference it **by name**.
+   read by `/aep-build`, `/aep-validate`, and `/aep-launch`; every other change site cross-references
+   it **by name**.
 2. **`skills/patterns/executor/references/dogfood-validation.md`** — Unified report format
-   (`:160-199`): add the required `**Failure-Class:**` line and the four-way routing table
-   (`environment` → ops checklist, never story-filing; `harness-flake` → quarantine; `scope` →
-   re-slice; `product-defect` → existing adapter path).
+   (`:160-199`): the required `**Failure-Class:**` line + the four-way routing table. Config block
+   (`:203-232`): a cross-reference stating `live_policy` lives in the e2e skill's `policy.md`, not
+   in `topology.routing.dogfood`.
 3. **`skills/project-setup/e2e-skill-scaffolding/`** — `templates/policy.md.tmpl` + SKILL.md Phase 2
-   confirmation questions gain the `live_policy` decision and the preflight-probe list;
-   `references/layer-gate-loop.md` and `references/three-tier-model.md` add the environment
-   preflight gate (named refusals before any Tier-2/3 spend), the evidence-class requirement on
-   `passed`, and the replay-placement note (impacted per story, full per layer).
-4. **`skills/agentic-development-workflow/build/SKILL.md`** — Phase 5 (`:126-145`): round cap and
-   evaluator effort read from the brief's `verification_tier`; taxonomy check at every FAIL before
-   any ladder rung. Phase 6 Step B (`:194-215`): run the preflight gate before executing; a refusal
-   is `environment`, not a dogfood FAIL. Phase 8 (`:237`): impacted-only journey replay.
-5. **`skills/patterns/gen-eval/references/`** — `eval-protocol.md` (`:116`): `max_rounds` becomes
-   tier-derived. `recovery-ladder.md` (`:59-67`): "When to Skip the Ladder" reframed as the typed
-   taxonomy step run at every FAIL. `scoring-framework.md`: state the zero-blocking-findings
-   threshold semantics and name the perfect-score gate as an anti-pattern.
-6. **`skills/agentic-development-workflow/wrap/references/`** — `convergence.md` (`:70-88`): the
-   `verification:` block in `execution-record.yaml`. `layer-advance.md`: full replay owned here; the
-   budget box; the evidence-class check before flipping `passed`.
-7. **`skills/product-context/dispatch/SKILL.md`** — tier derivation at brief assembly (`:237`,
-   machine-assembled; the observable inputs listed above), recorded in the brief and the dispatch
-   note.
-8. **`skills/product-context/reflect/SKILL.md`** (+ `watch` → `references/telemetry-ingestion.md`) —
-   escape-rate ingestion (trace post-merge bugs to origin stories' `escaped_defects`); distillation
-   may propose tier-derivation and journey-retirement changes, proposal-only.
-9. **`docs/glossary.md`** — new entries: **Verification Tier**, **Failure Class (Failure
-   Taxonomy)**, **Environment Preflight Gate**, **Verification Accounting**, **Escape Rate**,
-   **Tamper-Evident Evidence**, **Verification Ratchet** (anti-pattern), **Perfect-Score Gate**
-   (anti-pattern).
-10. `CHANGELOG.md` `[3.1.0]`; `.claude-plugin/marketplace.json` + `package.json` → `3.1.0`.
-    Product-context skills' edits (dispatch, reflect, watch) go through `_shared/` sources +
-    `build-skills.sh` per the generated-dirs rule.
+   confirmation questions gain the `live_policy` decision, the `sensitive_paths` list, and the
+   preflight probe sets (deploy-independent vs target-bound, with web **and** cli/tui probe
+   vocabularies); `templates/layer-gate-evidence.md.tmpl` gains the budget box;
+   `templates/tool-selection.md.tmpl` notes REFUSED vs SKIP semantics;
+   `references/layer-gate-loop.md` and `references/three-tier-model.md` add the preflight gate, the
+   evidence-class requirement on `passed`, and the replay-placement note.
+4. **`skills/agentic-development-workflow/build/SKILL.md`** — Phase 5 (`:126-145`): tier-capped
+   rounds, the taxonomy check at every FAIL, cap-exhaustion auto-escalation. Phase 6 Step B
+   (`:192-215`): deploy-independent preflight on every story; target-bound preflight when execution
+   runs here. Phase 8 (`:237`): impacted-only replay + canary + the `deep` exception.
+5. **`skills/patterns/gen-eval/references/`** — `eval-protocol.md` (`:116`): tier-derived
+   `max_rounds`; evaluator-authored `failure_class` in the response format; per-round response
+   persistence. `recovery-ladder.md` (`:3`, `:25-31`, `:59-67`): the second `max_rounds` copy; rungs
+   re-keyed relative to the tier cap; "When to Skip the Ladder" reframed as the typed taxonomy step
+   with the class mapping. `scoring-framework.md`: zero-blocking threshold semantics; perfect-score
+   gates named as an anti-pattern.
+6. **`skills/agentic-development-workflow/launch/references/evaluator.md`** (`:73-74`) — the third
+   `max_rounds` copy goes tier-derived.
+7. **`skills/agentic-development-workflow/wrap/references/`** — `convergence.md` (`:70-88`): the
+   `verification:` block. `layer-advance.md`: full replay + mid-layer checkpoint policy + budget box
+   - evidence-class check before flipping `passed`.
+8. **`skills/product-context/dispatch/`** — `references/context-assembly.md` (the assembly-time
+   home): provisional tier derivation into the machine-assembled brief; `SKILL.md` (`:237`) notes
+   the binding re-derivation at the merge boundary.
+9. **`skills/product-context/_shared/references/telemetry-ingestion.md`** (regenerated into
+   `reflect/` and `watch/` via `build-skills.sh`) — the `dogfood_report` adapter parses
+   `**Failure-Class:**`; `environment` / `harness-flake` / `scope` findings **never auto-file**
+   stories; escape-rate ingestion appends `escaped_defects`.
+10. **`skills/patterns/autopilot/`** — `references/tick-protocol.md`: REFUSED ≠ FAIL at the gate (a
+    refused gate pauses cheaply with the ops checklist and **re-probes world-derived on each tick**,
+    so human repair auto-resumes; remaining in-layer stories may still dispatch);
+    "`eval_not_converging` after the ladder is exhausted" becomes tier-derived.
+    `references/state-schema.md` (`:138`): a new `environment_repair` escalation type carrying the
+    checklist. `references/post-merge-guard.md`: preflight before the guard's dogfood;
+    `Failure-Class:` in the guard report; `live_policy` governs the guard's live half.
+11. **`skills/agentic-development-workflow/design/references/workflow-modes.md`** — Light mode's
+    eval-loop behavior subsumed into `verification_tier: light`.
+12. **`docs/glossary.md`** — new entries: **Verification Tier**, **Failure Class (Failure
+    Taxonomy)**, **Classification Authority**, **Environment Preflight Gate**, **Verification
+    Accounting**, **Escape Rate**, **Tamper-Evident Evidence**, **Verification Ratchet**
+    (anti-pattern), **Perfect-Score Gate** (anti-pattern) — the Verification Tier entry
+    disambiguates the three prior "light" senses.
+13. `CHANGELOG.md` `[3.1.0]`; `.claude-plugin/marketplace.json` → `3.1.0` (the sole versioned
+    field). If any skill description changes, re-record the front-tier description digest and update
+    `docs/skills-quick-reference.md`. Among the sites above, only `telemetry-ingestion.md` is
+    `_shared/`-managed; the SKILL.md and skill-owned reference edits are made in place.
 
 **Future — explicit non-goals, recorded as horizon:**
 
@@ -310,73 +442,101 @@ no new required schema fields:**
 
 ## Forcing functions
 
-| Skill           | New responsibility                                                                                              |
-| --------------- | --------------------------------------------------------------------------------------------------------------- |
-| `/aep-gen-eval` | Owns the verification-economics reference; tier-derived round caps; zero-blocking threshold semantics           |
-| `/aep-build`    | Preflight before dogfood; taxonomy check before any ladder rung; impacted-only replay; tier read from the brief |
-| `/aep-wrap`     | Full replay + budget box + evidence-class check at the layer gate; gathers the `verification:` block            |
-| `/aep-dispatch` | Derives `verification_tier` from observable facts into the machine-assembled brief                              |
-| `/aep-reflect`  | Routes on `failure_class`; ingests escape rate; proposes bidirectional calibration                              |
-| e2e scaffold    | `live_policy` + preflight probes in `policy.md`; evidence classes and replay placement in the gate loop         |
+| Skill            | New responsibility                                                                                                        |
+| ---------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| `/aep-gen-eval`  | Owns the verification-economics reference; tier-derived caps; evaluator-authored `failure_class`; zero-blocking semantics |
+| `/aep-build`     | Preflight before dogfood; taxonomy check before any ladder rung; impacted replay + canary; cap-exhaustion escalation      |
+| `/aep-wrap`      | Full replay + checkpoints + budget box + evidence-class check at the gate; gathers the `verification:` block              |
+| `/aep-dispatch`  | Provisional tier into the machine-assembled brief; binding re-derivation contract at the merge boundary                   |
+| `/aep-reflect`   | Routes on `failure_class`; ratifies `harness-flake`; ingests escape rate; proposes dampened calibration                   |
+| `/aep-autopilot` | REFUSED ≠ FAIL tick handling; `environment_repair` escalation; preflight + `live_policy` on the post-merge guard          |
+| `/aep-launch`    | Evaluator round cap read from the tier                                                                                    |
+| e2e scaffold     | `live_policy` + `sensitive_paths` + probe sets in `policy.md`; budget box in the gate evidence template                   |
 
 ## Migration
 
-All changes are prose-additive and fail open: a story with no derived tier behaves as `deep`
-(today's behavior); a report without `Failure-Class:` classifies as `product-defect` (today's
-routing); an execution record without `verification:` stays valid (`story_id` remains the only
-required field); a gate with no named evidence class records a warning, not a refusal, for one
-release.
+All changes are prose-additive and fail open — with the honesty note that fail-open means
+**non-adopting consumers keep today's cost, not today's cost minus savings**: a story with no
+derived tier behaves as `deep` (today's full-mode behavior; a design-time Light-mode run keeps its
+existing skips and maps to `light`); a report without `Failure-Class:` classifies as
+`product-defect` (today's routing — and also the tamper-resistance default); an execution record
+without `verification:` stays valid (`story_id` remains the only required field); a gate with no
+named evidence class records a warning, not a refusal, for one release. Standalone projects (no
+`product-context.yaml`) never get derivation and therefore run `deep` permanently unless the human
+sets a tier by hand.
 
-| Phase                       | Action                                                                                   | Breaking? |
-| --------------------------- | ---------------------------------------------------------------------------------------- | --------- |
-| **P0 — this decision doc**  | Record the evidence, the placement principle, the five design elements                   | No        |
-| **P1 — canon reference**    | Ship `gen-eval/references/verification-economics.md` + glossary entries                  | No        |
-| **P2 — taxonomy carriers**  | Dogfood report `Failure-Class:` + preflight gate (executor, e2e scaffold, build Phase 6) | No        |
-| **P3 — tiers + accounting** | Tier derivation (dispatch), tier-derived rounds (build/gen-eval), `verification:` (wrap) | No        |
-| **P4 — calibration + bump** | Reflect/distillation calibration, replay move, budget box; v3.1.0                        | No        |
+**Consumer adoption step (mid-layer re-pins):** a consumer re-pinning with open failed/blocked gate
+records runs a **one-time reclassification pass before any dispatch** — existing failure records are
+re-labeled under the taxonomy (looplia's L31 `prod_dogfood: FAIL` becomes `environment` + ops
+checklist), and acceptance criteria authored solely by misrouted recovery stories are re-sliced out
+of the coverage denominator via `/aep-reflect` (`scope`), so a poisoned gate can reach `passed` once
+the environment is actually repaired.
+
+| Phase                       | Action                                                                                                                           | Breaking? |
+| --------------------------- | -------------------------------------------------------------------------------------------------------------------------------- | --------- |
+| **P0 — this decision doc**  | Record the evidence, the placement principle, the five design elements                                                           | No        |
+| **P1 — canon reference**    | Ship `gen-eval/references/verification-economics.md` + glossary entries                                                          | No        |
+| **P2 — taxonomy carriers**  | `Failure-Class:` + classification authority + preflight + adapter routing (executor, e2e, build, shared)                         | No        |
+| **P3 — tiers + accounting** | Two-point derivation (dispatch/build), tier-derived caps (build/gen-eval/launch), `verification:` + per-round persistence (wrap) | No        |
+| **P4 — calibration + bump** | Reflect/distillation dampened calibration, replay move + checkpoints, budget box, autopilot integration; v3.1.0                  | No        |
 
 **Exact change sites:** the numbered list under "What upstream changes now" is the implementation
 PRs' review contract.
 
 **Propagation discipline:** this proposal introduces net-new taxonomy — _failure class_,
-_verification tier_, _environment preflight gate_, _tamper-evident evidence_, _escape rate_,
-_verification ratchet_, _perfect-score gate_ — and two new enums (`failure_class` values;
-`live_policy` values). Every skill that names one must say it identically; the glossary defines
-each; audit with `grep -rn "failure_class\|verification_tier\|live_policy\|preflight" skills/ docs/`
-after implementation. `live_policy` joins `applicable_tiers`/`dogfood_target`/`journey_timing` in
-**every** policy listing (e2e templates, three-tier-model, layer-gate-loop, build Phase 6, wrap) —
-half-applied enums are this repo's #1 historical bug class. Dispatch/reflect/watch edits are made in
-`skills/product-context/_shared/` and regenerated via `scripts/build-skills.sh`; `skills:check` must
-come back clean. Downstream consumers go live only after the v3.1.0 tag is cut and each consumer
-re-pins via the skills CLI.
+_classification authority_, _verification tier_, _environment preflight gate_, _tamper-evident
+evidence_, _escape rate_, _verification ratchet_, _perfect-score gate_ — and two new enums
+(`failure_class` values; `live_policy: every_gate | milestone_gates_only | none`). Every skill that
+names one must say it identically; the glossary defines each; audit with
+`grep -rn "failure_class\|verification_tier\|live_policy\|sensitive_paths\|preflight" skills/ docs/`
+after implementation. The `live_policy` propagation set is enumerated (per the half-applied-enum
+history): `templates/policy.md.tmpl`, `e2e-skill-scaffolding/SKILL.md`, `three-tier-model.md`,
+`layer-gate-loop.md`, `build/SKILL.md` Phase 6, `wrap/references/layer-advance.md`,
+`executor/references/dogfood-validation.md` (Config block cross-reference),
+`_shared/templates/product-context-schema.yaml` (`:415-418` routing comment, `:451-459` layer-gate
+comments), `map/SKILL.md` (`:116`, `:217`), `scaffold/references/resulting-structure.md`, and
+`autopilot/references/post-merge-guard.md`. The existing `error_class` enum is **not** renamed; its
+mapping into `failure_class` lives in the canon reference. `_shared/` edits regenerate via
+`scripts/build-skills.sh`; `skills:check` must come back clean. Downstream consumers go live only
+after the v3.1.0 tag is cut and each consumer re-pins via the skills CLI — **after** first
+completing the v2.5.0 → v3.0.0 re-pin per the
+[migration guide](../aep-v3.0.0-migration-guide.md), so routing changes and verification-semantics
+changes are canaried separately.
 
 ---
 
 ## Worked examples
 
-**looplia L31, replayed under this design.** The post-deploy gate's preflight probes run before any
-scenario: `REFUSING [dogfood-secret-absent:LOOPLIA_E2E_FIXTURE_SECRET]`,
-`REFUSING [auth-identity-mismatch:account …d422b ≠ …88e6]`. Classification is `environment` by
-construction — an ops checklist (set the two secrets, re-auth Wrangler to the prod account) surfaces
-to the human; the gate stays `scripted_passed` with named blockers. **Zero journey scenarios spent,
-zero code stories filed, zero evaluation rounds, no autopilot halt.** The actual history — two
-recovery stories, ten exhausted evaluation rounds, a paused loop, and a layer stuck at 68/75
-coverage on criteria the recovery itself created — is the cost of routing an environment failure
-through product-defect machinery.
+**looplia L31, replayed under this design.** The deploy-independent preflight runs pre-merge on the
+first L31 story: `REFUSING [dogfood-secret-absent:LOOPLIA_E2E_FIXTURE_SECRET]` (the GitHub secret
+name was checkable without any deploy) — the ops checklist surfaces days before the gate. Whatever
+slips through, the gate-time target-bound preflight refuses with
+`REFUSING [auth-identity-mismatch:account …d422b ≠ …88e6]` before any scenario spend. Classification
+is `environment` by construction; the ownership check pairs it with `product-defect` findings for
+the unwired deploy binding and the tracked literal-password fallback — filed as ordinary stories,
+not spun into recovery loops. **Zero journey scenarios wasted, zero evaluation rounds, no
+misclassified recovery stories.** The loop still pauses on the human ops checklist — environment
+repair is genuinely human work — but it pauses **immediately, cheaply, and correctly labeled**, with
+the gate re-probing on each tick so repair auto-resumes; the actual history (two recovery stories,
+ten exhausted rounds, a layer stuck at 68/75 on criteria the recovery itself authored) is the cost
+of routing an environment failure through product-defect machinery.
 
-**SIBYL-189, replayed under `standard` tier.** Round 1 caught two real findings (armed-quit
-priority, a matrix misclassification the new oracle exposed); the fixes landed; round 2 passed with
-zero blocking findings — exactly the two rounds `standard` allows, so the catch quality is
-unchanged. What the tier removes: the second full-suite run (~13 minutes; the land verify already
-runs the suite on merged main) and the top-shelf evaluator profile for a display-positioning story —
-the findings were caught by the focused matrix oracle and an ordinary evaluation round, not by
-`xhigh` reasoning. The PTY journey and ledger-equality dogfood stay: they are the tamper-evident
-half of the gate.
+**SIBYL-189, replayed under the derivation.** Provisional: multi-module `files_affected`, contract
+obligations, not a walking-skeleton layer, no `sensitive_paths` match → `standard`. Binding: the
+merged diff stays inside declared scope → `standard` holds. Round 1 caught two real findings; the
+fixes landed; round 2 passed with zero blocking findings — exactly `standard`'s one
+fix-and-reverify cycle, so the catch quality is unchanged. What the tier removes: the second
+full-suite run (~13 minutes; the land verify already runs the suite on merged main) and the
+top-shelf evaluator profile for a display-positioning story. The PTY journey and ledger-equality
+dogfood stay: they are the tamper-evident half of the gate. (An integration-gate story like
+looplia's L31-006 also derives `standard` — and that is safe **because the layer gate's depth is
+wrap-owned**, not a property of the story's tier.)
 
 **SIBYL's `live_policy: milestone_gates_only`** (live-model dogfoods only at the L2/L4/L6 milestone
 gates; zero-quota render smokes elsewhere) is the proven downstream shape of the `live_policy`
 decision this proposal adds to `policy.md` — evidence that pricing the expensive half of dogfood
-per-gate, instead of running it uniformly, holds up across 20+ layers of real use.
+per-gate, instead of running it uniformly, holds up across 20+ layers of real use. Its SKIP-not-FAIL
+degrade for the optional live half is preserved verbatim by the `live_policy`-aware preflight rule.
 
 ---
 
@@ -385,19 +545,23 @@ per-gate, instead of running it uniformly, holds up across 20+ layers of real us
 - **Perfect-score gates.** "Exactly 5.00/5.00 with zero findings" trains the generator to satisfy
   the evaluator, not the product, and turns ordinary convergence into round exhaustion. PASS is zero
   blocking findings.
+- **Self-classified failures.** A generator that labels its own FAIL `harness-flake` or
+  `environment` is player, referee, and witness at once; spend-reducing classes require
+  non-generator evidence, and the default is `product-defect`.
 - **Environment failures fed to code-repair machinery.** A missing secret is not a 2.79/5.00 code
   problem; no evaluation round may be spent before the taxonomy step runs.
 - **Per-story full-regression replay.** O(layers × stories) journey executions; full replay belongs
-  to the layer gate.
+  to the layer gate and its checkpoints.
 - **Uninstrumented verification.** 444 ticks with `total_cost_usd: 0` recorded means the loop cannot
   know it is over-verifying; unpriced spend grows until it displaces the product.
 - **The verification ratchet.** A lessons loop that only ever adds verification converges on a
-  process that verifies instead of shipping; calibration must be able to loosen and retire.
+  process that verifies instead of shipping; calibration must be able to loosen and retire — with
+  dampers, because asymmetric feedback oscillates.
 - **Scaling verification with judge rounds.** More LLM-judge rounds is the only scaling direction
   that gets more expensive and more gameable at once; add typed gates and real-environment evidence
   instead.
-- **Self-curated evidence.** A generator that assembles its own evaluator's context, or can write
-  the fixtures it is graded against, is player, referee, and witness at once.
+- **Self-curated evidence.** A generator that assembles its own evaluator's context, writes the
+  fixtures it is graded against, or edits the CI workflows that judge it, is not being verified.
 
 ---
 
@@ -408,14 +572,17 @@ per-gate, instead of running it uniformly, holds up across 20+ layers of real us
   lifecycle and the ledger-equality oracle.
 - `looplia/.dev-workflow/autopilot-status.md`, `looplia/.dev-workflow/dogfood-l31-006.md` and
   `…/dogfood-l31-006/02-auth-recovery-audit.md`, `looplia/lessons-learned/l31-014-…md` — the L31
-  halt, the environment misrouting, and the perfect-score ratchet.
-- `SIBYL/product-context.yaml` → `topology.routing.dogfood.live_policy: milestone_gates_only` — the
-  downstream prior art for `live_policy`.
+  halt, the environment misrouting, the dual-class product findings, and the perfect-score ratchet.
+- `SIBYL/product-context.yaml` → `topology.routing.dogfood.live_policy: milestone_gates_only` and
+  `SIBYL/skills/e2e-test/tool-selection.md` (SKIP-not-FAIL degrade) — the downstream prior art for
+  `live_policy` and the REFUSED/SKIP distinction.
 - [deterministic-orchestration.md](deterministic-orchestration.md) — the mechanical/judgment split
   and typed-gate pattern this document extends to verification routing, depth, and accounting.
 - [build-convergence-pipeline.md](build-convergence-pipeline.md) — the execution-record gather this
   document's `verification:` block rides on.
 - [2026-07-15 looplia compatibility audit](../audits/2026-07-15-looplia-v2.5.0-to-v3.0.0-compatibility.md)
-  — the v2.5→v3 baseline both consumers migrate across before any of this lands downstream.
+  and the [v3.0.0 migration guide](../aep-v3.0.0-migration-guide.md) — the v2.5→v3 baseline both
+  consumers cross before any of this lands downstream.
 - Affected skills: `/aep-gen-eval`, `/aep-build`, `/aep-wrap`, `/aep-dispatch`, `/aep-reflect`,
-  `/aep-watch`, `/aep-e2e-skill-scaffolding`, `/aep-executor`.
+  `/aep-watch`, `/aep-autopilot`, `/aep-launch`, `/aep-design`, `/aep-e2e-skill-scaffolding`,
+  `/aep-executor`.

--- a/docs/decisions/verification-economics.md
+++ b/docs/decisions/verification-economics.md
@@ -13,11 +13,16 @@ _verification itself_ — the routing, depth, and accounting of verification are
 judging content stays judgment.
 
 > **Status:** Proposal (not yet implemented). This document records the design precisely so the
-> implementation PRs (target: v3.1.0) can be made and reviewed against it. It changes how AEP works,
-> so it lives in `decisions/` per the [docs routing guide](../README.md). Revised after a three-lens
-> design review (factual grounding, adversarial critique, downstream operability); the review's
-> blocking findings are folded in below — classification authority, two-point tier derivation,
-> cap-exhaustion semantics, autopilot integration, and the `live_policy`-aware preflight.
+> implementation PRs can be made and reviewed against it — **across two releases**: v3.1.0 ships
+> the incident-proven half (taxonomy, preflight, deterministic security gates, replay move,
+> evaluator-independence fixes, accounting instrumentation); v3.2.0 ships the economics half
+> (tiers, recipes, calibration), gated on field data from a v3.1.0 consumer. It changes how AEP
+> works, so it lives in `decisions/` per the [docs routing guide](../README.md). Revised after a
+> three-lens design review (factual grounding, adversarial critique, downstream operability) and an
+> independent frontier-model best-practice evaluation; their blocking findings are folded in below
+> — classification authority, two-point tier derivation, cap-exhaustion semantics, autopilot
+> integration, the `live_policy`-aware preflight, the referee-asset rule, and the typed recipe
+> artifact.
 
 > **Sourcing note:** Sourced from the 2026-07-16 cross-repo research session over SIBYL (story
 > SIBYL-189, `openspec/changes/archive/2026-07-15-SIBYL-189/`, and
@@ -96,13 +101,13 @@ reward-hacking future model — satisfy the check without satisfying the intent?
 > **Cheap and tamper-evident validators run in the inner loop, always. Expensive or gameable
 > validators run at the outermost boundary that still catches their failure class, gated by risk.**
 
-| DevOps position                  | Validators                                                                                              | Properties                                            | Frequency                       |
-| -------------------------------- | ------------------------------------------------------------------------------------------------------- | ----------------------------------------------------- | ------------------------------- |
-| **Inner loop** (per task/commit) | Typed gates: lint, typecheck, focused Tier-1, schema validation, scope gates, **environment preflight** | Deterministic, named refusals, cannot be rationalized | Every commit                    |
-| **Merge boundary** (per story)   | One decisive evaluator cycle (diff vs. acceptance contract; tier-capped rounds) + CI + Tier-3 drivers   | Expensive, partially gameable → risk-tiered rounds    | Once per story under `standard` |
-| **Deploy boundary** (per layer)  | Tier-2 journey dogfood on the real target, **full regression replay**, coverage matrices, gate evidence | Expensive but tamper-evident (real execution)         | Once per layer                  |
-| **Operate** (post-deploy)        | Telemetry / production outcomes → `/aep-watch` → `/aep-reflect`                                         | The least gameable evidence that exists               | Continuous                      |
-| **Human gate**                   | Residual-risk acceptance at layer advance; taxonomy escalations                                         | Most expensive                                        | Per layer + exceptions          |
+| DevOps position                  | Validators                                                                                                                      | Properties                                            | Frequency                       |
+| -------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------- | ------------------------------- |
+| **Inner loop** (per task/commit) | Typed gates: lint, typecheck, focused Tier-1, schema validation, scope gates, **secret scan / SAST**, **environment preflight** | Deterministic, named refusals, cannot be rationalized | Every commit                    |
+| **Merge boundary** (per story)   | One decisive evaluator cycle (diff vs. acceptance contract; tier-capped rounds) + CI + Tier-3 drivers                           | Expensive, partially gameable → risk-tiered rounds    | Once per story under `standard` |
+| **Deploy boundary** (per layer)  | Tier-2 journey dogfood on the real target, **full regression replay**, coverage matrices, gate evidence                         | Expensive but tamper-evident (real execution)         | Once per layer                  |
+| **Operate** (post-deploy)        | Telemetry / production outcomes → `/aep-watch` → `/aep-reflect`                                                                 | The least gameable evidence that exists               | Continuous                      |
+| **Human gate**                   | Residual-risk acceptance at layer advance; taxonomy escalations                                                                 | Most expensive                                        | Per layer + exceptions          |
 
 Two consequences worth naming:
 
@@ -241,10 +246,34 @@ between planning and merge:
   a human-owned list in the generated e2e skill's `policy.md` covering auth, payments, irreversible
   data operations, migrations, deploy/CI config; **or** the layer is the walking skeleton (0/0.5);
   **or** a human override says so. This is the hard floor; it is never loosenable by calibration.
-- **`light`** iff all: the change is docs/tests-only by path, no contract obligations, no new
-  non-test files — confirmed by the binding diff, not just the plan.
+- **`light`** iff all: the change is **docs-only** by path (tests are _not_ docs — see the
+  referee-asset rule below), no contract obligations, no new non-doc files — confirmed by the
+  binding diff, not just the plan.
 - **`standard`** otherwise (the default; multi-module or `on_critical_path` stories are at least
   `standard`).
+
+**Referee assets never derive `light`.** Test directories, journey specs
+(`skills/e2e-test/journeys/**`, including their `paths:` front-matter), the e2e skill's
+`policy.md`, and CI workflow definitions are the evidence base every later verifier stands on — a
+diff confined to them is a change to the _referee_, not a cheap change. The design already refuses
+generator edits to `.github/workflows/**` ("a generator that edits its own referee is not
+evidence", § Design 5); the same rule must cover the rest of the referee class, or the derivation
+function hands the reward-hacking generator a designed-in channel: delete assertions or weaken
+oracles in a tests-only diff and receive the cheapest, self-reviewed tier by construction — and the
+taxonomy _funnels_ work into that hole, because a `harness-flake` quarantine story is typically
+tests-only. Therefore: **a diff touching referee assets floors at `standard`**, and a **negative
+assertion delta** (more test/`Verify` lines removed than added) always requires an evaluation
+round, whatever the tier. Journey `paths:` edits after first authoring trigger the same scope
+refusal as workflow edits.
+
+**The recipe is a typed artifact, not a remembered rule.** The binding derivation emits
+`.dev-workflow/verification-recipe.json` (tier, dimension preset, hard floors, referee-asset and
+`scope_drift` flags), and **Phase 5 refuses to start without it** — by the companion doc's own law,
+a derivation function executed from prose recall is exactly the class of mechanical step that
+eventually gets skipped. Downstream projects get a runnable reference implementation (derivation
+function + preflight probe stubs + recipe emission) shipped with the e2e scaffolding skill —
+reference scripts are established precedent there (`scripts/audit.sh`, `scripts/converge.sh`);
+AEP still ships no runtime.
 
 | Tier                   | Evaluator rounds (cap)                      | Evaluator effort  | Dogfood scope (Phase 6B)          | Full-suite runs               |
 | ---------------------- | ------------------------------------------- | ----------------- | --------------------------------- | ----------------------------- |
@@ -264,6 +293,9 @@ floors — from one set of inputs:
 
 - `sensitive_paths` match → **Security-sensitive preset**, and its `Security ≥ 4` /
   `Data Privacy ≥ 4` floors become part of the tier hard floor — they survive any customization;
+  the recipe also adds the **deterministic security gates** (secret scan, SAST) as inner-loop typed
+  gates — the mechanically detectable half of security must never be routed to a more expensive LLM
+  judge, and their findings are `product-defect` by construction;
 - `ui`-kind module / `calibration_type` in {visual-design, ux-flow} / `object_model_refs` →
   **UI-heavy preset**, and only these stories pay for **Visual Design** — the most expensive
   dimension (screenshot capture + multimodal evaluation). Dimension cost follows the shipped
@@ -276,7 +308,10 @@ floors — from one set of inputs:
 Customization keeps the ratchet direction: launch or the human may **add** dimensions or raise
 thresholds, never drop a derived preset's hard-floor dimensions — the same
 tamper-resistance rule as the tier binding. Per tier: `light` scores no dimensions (self-review);
-`standard` runs the derived preset; `deep` runs it with no de-weighted dimensions. The framework's
+`standard` runs the derived preset; `deep` runs it with no de-weighted dimensions — and, where more
+than one model family is available, **`deep`-tier evaluation prefers a different model family from
+the generator**: cross-family judging reduces correlated generator/judge blind spots (SIBYL's
+`gpt-5.6-terra`-judging-Claude-output split is the downstream prior art). The framework's
 existing advice — _"weight dimensions toward areas where the model falls short"_ — becomes
 data-driven through the accounting below: findings and escapes are attributable per dimension, so
 calibration can propose re-weighting from evidence instead of intuition.
@@ -331,20 +366,26 @@ light` instead of carrying its own eval-loop toggle, collapsing the repo's three
 
 ### 3. Verification accounting — priced, recorded, calibrated
 
-`execution-record.yaml` (`wrap/references/convergence.md:70-88`) gains a `verification:` block. Every
-field is nullable and carries a named gather source (the gather stays best-effort):
+`execution-record.yaml` (`wrap/references/convergence.md:70-88`) gains a `verification:` block. The
+fields split into a **mandatory file-derivable floor** — every field marked `MUST` below is
+computable from artifacts the workflow already writes, and an implementation that leaves them null
+has not implemented this design — and best-effort fields that stay nullable. The motivating
+evidence is the warning: looplia ran 444 ticks with `total_cost_usd: 0`; a calibration loop built
+on optional sensors starves.
 
 ```yaml
 verification:
-  tier: light | standard | deep # provisional from the brief; Phase 5 binding re-derivation wins
-  tier_escalated: true | false # cap-exhaustion escalation fired
-  scope_drift: true | false # binding diff left the declared files_affected
-  eval_rounds: <n> | null # from signals/eval-response-*.md count
-  findings_by_round: [<n>, ...] | null # blocking+important per round; needs per-round persistence
-  finding_dimensions: [<dimension>, ...] | null # dimensions breached across rounds; feeds dimension re-weighting
-  journey_scenarios_run: <n> | null # from the dogfood report
-  preflight_refusals: [] # named tags, if any; [] when preflight passed
-  cost_usd: <n> | null # verification share when separable
+  tier: light | standard | deep # MUST — from verification-recipe.json
+  tier_escalated: true | false # MUST — cap-exhaustion escalation fired
+  scope_drift: true | false # MUST — binding diff left the declared files_affected
+  generator_model: <id> | null # MUST when known — model swaps shift both escape rate and findings
+  evaluator_model: <id> | null # MUST when an evaluator ran
+  eval_rounds: <n> | null # MUST when an evaluator ran — from signals/eval-response-*.md count
+  findings_by_round: [<n>, ...] | null # MUST when an evaluator ran — needs per-round persistence
+  finding_dimensions: [<dimension>, ...] | null # dimensions breached across rounds; feeds re-weighting
+  journey_scenarios_run: <n> | null # MUST when a journey ran — from the dogfood report
+  preflight_refusals: [] # MUST — named tags; [] when preflight passed
+  cost_usd: <n> | null # best-effort — verification share when separable
   escaped_defects: [] # filled retroactively by /aep-reflect
 ```
 
@@ -368,16 +409,21 @@ Consumers close the loop:
   escapes surface a layer later), which is the textbook oscillation setup. Dampening rules:
   **loosening proposals require ≥2 layers of `findings_by_round` evidence and zero unresolved
   escape attributions; loosen at most one notch per layer; the `sensitive_paths` hard floor is
-  never loosenable.** Tightening has no such damper. Verification assets get the same lifecycle:
+  never loosenable.** Tightening has no such damper. **Calibration proposals must condition on
+  model version** (`generator_model` / `evaluator_model` from the accounting block): a model swap
+  shifts escape rate and findings-per-round simultaneously, and a loop that cannot see the swap
+  will misattribute the shift to tier settings. Verification assets get the same lifecycle:
   distillation may propose merging or retiring journeys that have replayed green for N layers with
   no coverage loss. Proposals only; a human applies them. This is what breaks the ratchet.
 - **The layer budget box:** each layer gate's evidence doc records expected vs. actual verification
   spend (rounds, suite runs/time, scenarios, `cost_usd` where known). **The expected values are
   human-owned** — set at layer planning or accepted from a distillation proposal — never authored by
-  the loop that is graded against them. When actuals overrun the box, `/aep-wrap` surfaces a
-  **scope-vs-verification tradeoff to the human** at the layer-advance gate — the loop asks, it does
-  not silently grind. (looplia's tick-444 halt is the degenerate form of this question, asked ten
-  rounds too late.)
+  the loop that is graded against them. **Cold start is defined, not improvised:** the first
+  instrumented layer runs with no box and only records; its observed actuals plus a human-chosen
+  margin become the next layer's expected values. When actuals overrun the box, `/aep-wrap`
+  surfaces a **scope-vs-verification tradeoff to the human** at the layer-advance gate — the loop
+  asks, it does not silently grind. (looplia's tick-444 halt is the degenerate form of this
+  question, asked ten rounds too late.)
 
 ### 4. Regression replay moves from story to layer granularity
 
@@ -390,8 +436,10 @@ Consumers close the loop:
   prior-layer set per story (the one exception to impacted-only).
 - **Per layer** (`/aep-wrap` layer gate, `wrap/references/layer-advance.md`): the **full**
   prior-layer replay stays here, once per layer. For large layers, a **mid-layer full-replay
-  checkpoint every k stories** (k chosen at layer planning; looplia's L31 had 14 stories — k=5
-  would have bounded defect lifetime to 5 merges) keeps gate-time bisects tractable.
+  checkpoint every k stories** keeps gate-time bisects tractable — and k is **derived, not an
+  unguided planning judgment**: default `k = min(5, ⌈N/3⌉)` for a layer of N stories, overridable
+  by the human (looplia's L31 had 14 stories — the default gives k=5, bounding defect lifetime to
+  5 merges).
 - **The honest tradeoff:** executions drop from O(layers × stories) to O(stories + layers), but a
   cross-cutting regression a story's diff does not intersect now lives until the next checkpoint or
   the gate — worst-case defect lifetime is k merges, and gate-time attribution costs a bisect. The
@@ -405,7 +453,9 @@ generator cannot modify**:
 
 1. a CI run bound to the merged SHA — **valid as tamper-evident only when the workflow definitions
    are outside the story's diff scope** (a diff touching `.github/workflows/**` triggers a scope
-   refusal or human review; a generator that edits its own referee is not evidence);
+   refusal or human review; a generator that edits its own referee is not evidence — and the same
+   refusal covers the rest of the referee-asset class from § Design 2: journey `paths:` re-scoping
+   after first authoring, and `policy.md` edits outside a scaffold run);
 2. journey execution performed by `/aep-wrap` (executes-never-authors — existing canon);
 3. **read-only golden fixtures with a ledger-equality oracle** — fixture trees the generator's
    workspace cannot write, verified by before/after equality of durable state (SIBYL's
@@ -415,10 +465,17 @@ generator cannot modify**:
 
 Additionally:
 
-- **Evaluator prompts are machine-assembled** (extending deterministic-orchestration's
-  machine-assembled brief to evaluation): the orchestrating layer — not the generator — assembles
-  the evaluator's context (criteria file, contract file, diff range), so the generator cannot curate
-  what its judge sees.
+- **Evaluator prompts are machine-assembled, and spawn authority leaves the player** (extending
+  deterministic-orchestration's machine-assembled brief to evaluation): the orchestrating layer —
+  not the generator — assembles the evaluator's context (criteria file, contract file, diff range),
+  so the generator cannot curate what its judge sees. Today the generator also _spawns_ its own
+  evaluator and authors `eval-request.md`, the narrative the judge reads first — two residual
+  player-referee channels. Where an orchestrating layer exists (autopilot already nudges Phase 5;
+  the main session in interactive runs), **it owns the evaluator spawn**; in genuinely standalone
+  builds the spawn recipe stays generator-invoked, but in every mode the machine-assembled
+  evaluator prompt marks `eval-request.md` as the **generator's untrusted claim** — data to verify,
+  never framing to adopt — consistent with the untrusted-output guard the companion doc already
+  mandates for subagent results.
 - **`policy.md` gains a `live_policy` decision** for cost-bearing dogfoods (live model calls, quota-
   or fee-metered targets): `every_gate | milestone_gates_only | none`, with the milestone list named
   in the policy — the value set matches the proven downstream shape (SIBYL's
@@ -429,48 +486,65 @@ Additionally:
 
 ---
 
-## What upstream changes now (v3.1.0) vs future
+## What upstream changes now (v3.1.0 / v3.2.0) vs future
 
-**Now — one teaching reference plus prose edits across the verification-touching skills; no runtime,
-no new required schema fields:**
+**The two halves of this design carry unequal evidence and get unequal commitment.** The
+taxonomy + preflight + replay half is proven by incident — it neutralizes looplia's L31 failure end
+to end. The tiers + recipes + calibration half is extrapolated from one story (SIBYL-189) and
+carries most of the prose surface. They therefore ship in two releases: **v3.1.0** = items marked
+(3.1) below — taxonomy carriers, preflight, deterministic security gates, replay move,
+evaluator-independence fixes, and the accounting **instrumentation** (record-only, so the field
+data exists); **v3.2.0** = items marked (3.2) — the tier/recipe machinery and the calibration loop
+that consume that data, gated on **≥2 layers of real accounting data from a re-pinned consumer**.
+One teaching reference plus prose edits across the verification-touching skills; no runtime, no new
+required schema fields:
 
-1. **NEW `skills/patterns/gen-eval/references/verification-economics.md`** — the canonical reference
+1. **(3.1) NEW `skills/patterns/gen-eval/references/verification-economics.md`** — the canonical reference
    carrying the placement matrix, the failure taxonomy + classification-authority table + routing,
    the `error_class` → `failure_class` mapping, the tier derivation function + two-point protocol,
    the `verification:` accounting schema with gather sources, the evidence-class catalog, and the
    worked examples. It lives under gen-eval because gen-eval already owns evaluation canon and is
    read by `/aep-build`, `/aep-validate`, and `/aep-launch`; every other change site cross-references
    it **by name**.
-2. **`skills/patterns/executor/references/`** — `dogfood-validation.md`: Unified report format
+2. **(3.1) `skills/patterns/executor/references/dogfood-validation.md`** — Unified report format
    (`:160-199`) gains the required `**Failure-Class:**` line + the four-way routing table; Config
    block (`:203-232`) gains a cross-reference stating `live_policy` lives in the e2e skill's
-   `policy.md`, not in `topology.routing.dogfood`. `backends.md`: the `executor.spawn_evaluator()`
-   recipes accept an optional evaluator-effort hint derived from the tier (`deep` → highest
-   available).
-3. **`skills/project-setup/e2e-skill-scaffolding/`** — `templates/policy.md.tmpl` + SKILL.md Phase 2
-   confirmation questions gain the `live_policy` decision, the `sensitive_paths` list, and the
-   preflight probe sets (deploy-independent vs target-bound, with web **and** cli/tui probe
-   vocabularies); `templates/layer-gate-evidence.md.tmpl` gains the budget box;
-   `templates/tool-selection.md.tmpl` notes REFUSED vs SKIP semantics;
+   `policy.md`, not in `topology.routing.dogfood`. **(3.2)** `backends.md`: the
+   `executor.spawn_evaluator()` recipes accept an optional evaluator-effort hint derived from the
+   tier (`deep` → highest available, preferring a different model family from the generator).
+3. **(3.1) `skills/project-setup/e2e-skill-scaffolding/`** — `templates/policy.md.tmpl` + SKILL.md
+   Phase 2 confirmation questions gain the `live_policy` decision, the `sensitive_paths` list, the
+   **deterministic security gates** (secret-scan/SAST commands the project confirms at scaffold),
+   and the preflight probe sets (deploy-independent vs target-bound, with web **and** cli/tui probe
+   vocabularies); `templates/layer-gate-evidence.md.tmpl` gains the budget box (record-only until
+   3.2); `templates/tool-selection.md.tmpl` notes REFUSED vs SKIP semantics;
    `references/layer-gate-loop.md` and `references/three-tier-model.md` add the preflight gate, the
-   evidence-class requirement on `passed`, and the replay-placement note.
-4. **`skills/agentic-development-workflow/build/SKILL.md`** — Phase 5 (`:126-145`): the **binding
-   tier re-derivation at Phase 5 entry** (before any round spends the cap), tier-capped rounds, the
-   taxonomy check at every FAIL, cap-exhaustion auto-escalation, and publishing
-   `verification_tier` / `tier_escalated` to `status.json`. Phase 6 Step B (`:192-215`):
+   evidence-class requirement on `passed`, and the replay-placement note. **(3.2)** a **runnable
+   reference implementation** in the generated skill's `scripts/` — derivation function + probe
+   stubs + `verification-recipe.json` emission (precedent: `aep-scaffold`'s `audit.sh` /
+   `converge.sh`; AEP still ships no runtime).
+4. **`skills/agentic-development-workflow/build/SKILL.md`** — **(3.1)** Phase 5: the taxonomy check
+   at every FAIL; evaluator spawn authority moves to the orchestrating layer where one exists, and
+   `eval-request.md` is marked the generator's untrusted claim. Phase 6 Step B (`:192-215`):
    deploy-independent preflight on every story; target-bound preflight when execution runs here.
-   Phase 8 (`:237`): impacted-only replay + canary + the `deep` exception. Phase 12: the tier
-   re-check on post-eval commits (sensitive-path drift ⇒ one fresh round at the upgraded tier).
-5. **`skills/patterns/gen-eval/references/`** — `eval-protocol.md` (`:116`): tier-derived
-   `max_rounds`; evaluator-authored `failure_class` in the response format; per-round response
-   persistence. `recovery-ladder.md` (`:3`, `:25-31`, `:59-67`): the second `max_rounds` copy; rungs
-   re-keyed relative to the tier cap; "When to Skip the Ladder" reframed as the typed taxonomy step
-   with the class mapping. `scoring-framework.md`: zero-blocking threshold semantics; perfect-score
-   gates named as an anti-pattern; the Customization Guide's preset-selection step becomes
-   **recipe-derived** (the derivation-inputs → preset + hard-floor mapping from § Design 2), with
-   the ratchet rule — customization adds dimensions or raises thresholds, never drops a derived
-   hard floor.
-6. **`skills/agentic-development-workflow/launch/`** — `SKILL.md` "Optional: Evaluator (Full
+   Phase 8 (`:237`): impacted-only replay + canary. **(3.2)** Phase 5 (`:126-145`): the **binding
+   tier re-derivation at Phase 5 entry** (before any round spends the cap) emitting
+   `verification-recipe.json` (Phase 5 refuses to start without it), tier-capped rounds,
+   cap-exhaustion auto-escalation, publishing `verification_tier` / `tier_escalated` to
+   `status.json`, and the `deep` full-replay exception in Phase 8. Phase 12: the tier re-check on
+   post-eval commits (sensitive-path drift ⇒ one fresh round at the upgraded tier).
+5. **`skills/patterns/gen-eval/references/`** — **(3.1)** `eval-protocol.md`: evaluator-authored
+   `failure_class` in the response format; per-round response persistence (the sensor data 3.2's
+   calibration needs). `agent-contracts.md`: the machine-assembled evaluator prompt treats
+   `eval-request.md` as the generator's untrusted claim. `recovery-ladder.md` (`:59-67`): "When to
+   Skip the Ladder" reframed as the typed taxonomy step with the class mapping.
+   `scoring-framework.md`: zero-blocking threshold semantics; perfect-score gates named as an
+   anti-pattern. **(3.2)** `eval-protocol.md` (`:116`) + `recovery-ladder.md` (`:3`, `:25-31`):
+   tier-derived `max_rounds`; rungs re-keyed relative to the tier cap. `scoring-framework.md`: the
+   Customization Guide's preset-selection step becomes **recipe-derived** (the derivation-inputs →
+   preset + hard-floor mapping from § Design 2), with the ratchet rule — customization adds
+   dimensions or raises thresholds, never drops a derived hard floor.
+6. **(3.2) `skills/agentic-development-workflow/launch/`** — `SKILL.md` "Optional: Evaluator (Full
    Mode)" (`:199-205`): evaluator existence, criteria, and effort become **recipe-derived from the
    dispatch brief** (light → no criteria file; standard → the derived dimension preset; deep →
    the derived preset with nothing de-weighted, at top effort) — this replaces the workflow-modes
@@ -482,39 +556,44 @@ no new required schema fields:**
    never drop derived hard floors).
    `references/signals-spec.md`: `status.json` gains `verification_tier`, `tier_escalated`, and
    latest-FAIL `failure_class` — the fields autopilot's tier-aware monitoring reads.
-7. **`skills/agentic-development-workflow/wrap/references/`** — `convergence.md` (`:70-88`): the
-   `verification:` block. `layer-advance.md`: full replay + mid-layer checkpoint policy + budget box
-   - evidence-class check before flipping `passed`.
-8. **`skills/product-context/dispatch/`** — `references/context-assembly.md` (the assembly-time
+7. **(3.1) `skills/agentic-development-workflow/wrap/references/`** — `convergence.md` (`:70-88`):
+   the `verification:` block with the mandatory file-derivable sensor floor (instrumentation ships
+   early so 3.2 has data). `layer-advance.md`: full replay + the derived mid-layer checkpoint +
+   evidence-class check before flipping `passed`; budget-box recording (cold-start: record-only on
+   the first instrumented layer). **(3.2)** `layer-advance.md`: budget-box overrun surfacing at the
+   layer-advance gate.
+8. **(3.2) `skills/product-context/dispatch/`** — `references/context-assembly.md` (the assembly-time
    home): provisional tier derivation into the machine-assembled brief (grouped changes take the
    max of member tiers); `SKILL.md` (`:237`) notes the binding re-derivation contract (Phase 5
    entry, build-owned). `references/workflow-mode.md`: the STEP-0 brief carries the tier; the
    workflow verify stage — that mode's evaluator — honors the tier cap.
-9. **`skills/product-context/_shared/references/telemetry-ingestion.md`** (regenerated into
+9. **(3.1) `skills/product-context/_shared/references/telemetry-ingestion.md`** (regenerated into
    `reflect/` and `watch/` via `build-skills.sh`) — the `dogfood_report` adapter parses
    `**Failure-Class:**`; `environment` / `harness-flake` / `scope` findings **never auto-file**
    stories; escape-rate ingestion appends `escaped_defects`.
-10. **`skills/patterns/autopilot/`** — `references/tick-protocol.md`: REFUSED ≠ FAIL at the gate (a
-    refused gate pauses cheaply with the ops checklist and **re-probes world-derived on each tick**,
-    so human repair auto-resumes; remaining in-layer stories may still dispatch);
-    "`eval_not_converging` after the ladder is exhausted" becomes tier-derived (fires only after
-    the published cap **plus** the automatic `standard → deep` escalation are spent); the ④b nudge
-    texts (`:212`, `:237`) go tier-aware — read `verification_tier` from `status.json`, nudge a
-    `light` workspace to self-review rather than "spawn the evaluator", and extend the stale-eval
-    nudge with the sensitive-path-drift upgrade. `references/state-schema.md` (`:138`): a new
-    `environment_repair` escalation type carrying the checklist.
-    `references/post-merge-guard.md`: preflight before the guard's dogfood; `Failure-Class:` in the
-    guard report; `live_policy` governs the guard's live half.
-11. **`skills/agentic-development-workflow/design/references/workflow-modes.md`** — Light mode's
-    eval-loop behavior subsumed into `verification_tier: light`.
-12. **`docs/glossary.md`** — new entries: **Verification Tier**, **Verification Recipe** (tier +
+10. **`skills/patterns/autopilot/`** — **(3.1)** `references/tick-protocol.md`: REFUSED ≠ FAIL at
+    the gate (a refused gate pauses cheaply with the ops checklist and **re-probes world-derived on
+    each tick**, so human repair auto-resumes; remaining in-layer stories may still dispatch); the
+    ④b Phase-5 trigger nudge notes the orchestrator owns the evaluator spawn.
+    `references/state-schema.md` (`:138`): a new `environment_repair` escalation type carrying the
+    checklist. `references/post-merge-guard.md`: preflight before the guard's dogfood;
+    `Failure-Class:` in the guard report; `live_policy` governs the guard's live half. **(3.2)**
+    `tick-protocol.md`: "`eval_not_converging` after the ladder is exhausted" becomes tier-derived
+    (fires only after the published cap **plus** the automatic `standard → deep` escalation are
+    spent); the ④b nudge texts (`:212`, `:237`) go tier-aware — read `verification_tier` from
+    `status.json`, nudge a `light` workspace to self-review rather than "spawn the evaluator", and
+    extend the stale-eval nudge with the sensitive-path-drift upgrade.
+11. **(3.2) `skills/agentic-development-workflow/design/references/workflow-modes.md`** — Light
+    mode's eval-loop behavior subsumed into `verification_tier: light`.
+12. **(3.1) `docs/glossary.md`** — new entries: **Verification Tier**, **Verification Recipe** (tier +
     dimension preset + dimension hard floors, one derivation), **Failure Class (Failure
     Taxonomy)**, **Classification Authority**, **Environment Preflight Gate**, **Verification
     Accounting**, **Escape Rate**, **Tamper-Evident Evidence**, **Verification Ratchet**
-    (anti-pattern), **Perfect-Score Gate** (anti-pattern) — the Verification Tier entry
-    disambiguates the three prior "light" senses.
-13. `CHANGELOG.md` `[3.1.0]`; `.claude-plugin/marketplace.json` → `3.1.0` (the sole versioned
-    field). If any skill description changes, re-record the front-tier description digest and update
+    (anti-pattern), **Perfect-Score Gate** (anti-pattern), **Referee Asset** — the Verification
+    Tier entry disambiguates the three prior "light" senses.
+13. `CHANGELOG.md` `[3.1.0]` and later `[3.2.0]`; `.claude-plugin/marketplace.json` bumps per
+    release (the sole versioned field — root `package.json` carries none). If any skill description
+    changes, re-record the front-tier description digest and update
     `docs/skills-quick-reference.md`. Among the sites above, only `telemetry-ingestion.md` is
     `_shared/`-managed; the SKILL.md and skill-owned reference edits are made in place.
 
@@ -562,13 +641,14 @@ checklist), and acceptance criteria authored solely by misrouted recovery storie
 of the coverage denominator via `/aep-reflect` (`scope`), so a poisoned gate can reach `passed` once
 the environment is actually repaired.
 
-| Phase                       | Action                                                                                                                           | Breaking? |
-| --------------------------- | -------------------------------------------------------------------------------------------------------------------------------- | --------- |
-| **P0 — this decision doc**  | Record the evidence, the placement principle, the five design elements                                                           | No        |
-| **P1 — canon reference**    | Ship `gen-eval/references/verification-economics.md` + glossary entries                                                          | No        |
-| **P2 — taxonomy carriers**  | `Failure-Class:` + classification authority + preflight + adapter routing (executor, e2e, build, shared)                         | No        |
-| **P3 — tiers + accounting** | Two-point derivation (dispatch/build), tier-derived caps (build/gen-eval/launch), `verification:` + per-round persistence (wrap) | No        |
-| **P4 — calibration + bump** | Reflect/distillation dampened calibration, replay move + checkpoints, budget box, autopilot integration; v3.1.0                  | No        |
+| Phase                                          | Action                                                                                                                                                                                                                                         | Breaking? |
+| ---------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------- |
+| **P0 — this decision doc**                     | Record the evidence, the placement principle, the five design elements                                                                                                                                                                         | No        |
+| **P1 — canon reference (v3.1.0)**              | Ship `gen-eval/references/verification-economics.md` + glossary entries                                                                                                                                                                        | No        |
+| **P2 — taxonomy carriers (v3.1.0)**            | `Failure-Class:` + classification authority + referee-asset rule + preflight + secret-scan/SAST + adapter routing + REFUSED≠FAIL/`environment_repair` + replay move/canary/checkpoints + evaluator spawn ownership/untrusted `eval-request.md` | No        |
+| **P2.5 — accounting instrumentation (v3.1.0)** | `verification:` sensor floor + per-round persistence + model-version fields + budget-box recording (cold-start record-only); **tag v3.1.0**                                                                                                    | No        |
+| **P3 — tiers + recipes (v3.2.0)**              | Two-point derivation + `verification-recipe.json` + reference script + tier caps (build/gen-eval/launch) + recipe-derived criteria + signals fields + tier-aware nudges — **gated on ≥2 layers of P2.5 field data from a re-pinned consumer**  | No        |
+| **P4 — calibration (v3.2.0)**                  | Dampened calibration + escape-rate ingestion + journey retirement + budget-box overrun surfacing; **tag v3.2.0**                                                                                                                               | No        |
 
 **Exact change sites:** the numbered list under "What upstream changes now" is the implementation
 PRs' review contract.
@@ -588,10 +668,10 @@ comments), `map/SKILL.md` (`:116`, `:217`), `scaffold/references/resulting-struc
 `autopilot/references/post-merge-guard.md`. The existing `error_class` enum is **not** renamed; its
 mapping into `failure_class` lives in the canon reference. `_shared/` edits regenerate via
 `scripts/build-skills.sh`; `skills:check` must come back clean. Downstream consumers go live only
-after the v3.1.0 tag is cut and each consumer re-pins via the skills CLI — **after** first
-completing the v2.5.0 → v3.0.0 re-pin per the
-[migration guide](../aep-v3.0.0-migration-guide.md), so routing changes and verification-semantics
-changes are canaried separately.
+after each release tag (v3.1.0, then v3.2.0) is cut and the consumer re-pins via the skills CLI —
+**after** first completing the v2.5.0 → v3.0.0 re-pin per the
+[migration guide](../aep-v3.0.0-migration-guide.md), so routing changes, taxonomy changes, and
+tier-economics changes are canaried separately, one release apart.
 
 ---
 
@@ -603,8 +683,9 @@ name was checkable without any deploy) — the ops checklist surfaces days befor
 slips through, the gate-time target-bound preflight refuses with
 `REFUSING [auth-identity-mismatch:account …d422b ≠ …88e6]` before any scenario spend. Classification
 is `environment` by construction; the ownership check pairs it with `product-defect` findings for
-the unwired deploy binding and the tracked literal-password fallback — filed as ordinary stories,
-not spun into recovery loops. **Zero journey scenarios wasted, zero evaluation rounds, no
+the unwired deploy binding — filed as an ordinary story, not spun into recovery loops. The tracked
+literal-password fallback never even reaches that path: the inner-loop **secret scan** catches it
+pre-merge as a typed gate, on the first story that committed it. **Zero journey scenarios wasted, zero evaluation rounds, no
 misclassified recovery stories.** The loop still pauses on the human ops checklist — environment
 repair is genuinely human work — but it pauses **immediately, cheaply, and correctly labeled**, with
 the gate re-probing on each tick so repair auto-resumes; the actual history (two recovery stories,

--- a/docs/decisions/verification-economics.md
+++ b/docs/decisions/verification-economics.md
@@ -1,0 +1,421 @@
+# Verification Economics: Risk-Tiered Validators and Tamper-Evident Evidence
+
+An empirical law from running two AEP consumer projects at scale: **verification whose cost is
+unpriced and whose depth is uniform eventually displaces the product it protects — and every observed
+loop failure was a verification-_placement_ error, not a verification-_volume_ error.** This document
+records how AEP prices verification and where each validator class belongs: a typed failure taxonomy
+evaluated before any repair spend, risk-derived verification depth per story, verification accounting
+in the convergence record, regression replay moved from story to layer granularity, and a
+tamper-evident-evidence requirement on every layer gate. Companion to
+[deterministic-orchestration.md](deterministic-orchestration.md): that document put the WHEN and SHAPE
+of _orchestration_ behind mechanism; this one applies the same mechanical/judgment split to
+_verification itself_ — the routing, depth, and accounting of verification are mechanical; only the
+judging content stays judgment.
+
+> **Status:** Proposal (not yet implemented). This document records the design precisely so the
+> implementation PRs (target: v3.1.0) can be made and reviewed against it. It changes how AEP works,
+> so it lives in `decisions/` per the [docs routing guide](../README.md).
+
+> **Sourcing note:** Sourced from the 2026-07-16 cross-repo research session over SIBYL (story
+> SIBYL-189, `openspec/changes/archive/2026-07-15-SIBYL-189/`, and
+> `skills/e2e-test/results/2026-07-16-s189-current-position.md`) and looplia (Layer 31,
+> `.dev-workflow/autopilot-status.md`, `.dev-workflow/dogfood-l31-006.md`, lessons
+> `l31-006`/`l31-014`), plus the framing that in the RLVR era stronger generator models make
+> LLM-judged verification simultaneously more expensive and more gameable — so verification must
+> scale through deterministic gates and real-environment evidence, not through more judge rounds.
+> SIBYL's concrete machinery (its Terra evaluator profile, shell-use PTY driver, ledger-equality
+> oracle) stays downstream; what upstreams here is the taxonomy, the tier model, the accounting
+> schema, and the placement rules.
+
+---
+
+## The evidence (diagnosis)
+
+Both v2.5.0 consumers now spend the majority of their loop on verification and process:
+
+- **looplia:** of the last 100 commits, **16 are feature-bearing PR merges; 84 are
+  dispatch/design/prove/complete/archive/lessons overhead** (≈1:5.3). Layer 31's 14 stories all
+  merged within three days — then the layer halted at autopilot tick 444 with **zero further product
+  advance**: the mandatory post-deploy production dogfood failed on a **pure environment
+  precondition** (prod secrets absent from CI, Wrangler OAuth bound to the wrong Cloudflare account).
+  The loop's only failure path routed this ops problem into **two code-fix recovery stories**, each of
+  which exhausted **all five** independent evaluation rounds and still failed (final rounds 2.79 and
+  3.28 of 5), pausing the loop for human redesign. Ten evaluation rounds were spent repairing a
+  problem no code change could fix. Verification cost is uninstrumented there
+  (`stats.total_cost_usd: 0` after 444 ticks).
+- **looplia's merge gate is a perfect-score gate:** a lesson (`l31-014`) ratcheted the threshold to
+  _"the independent evaluator must return exactly 5.00/5.00 with zero findings before PR/merge."_
+  Upstream AEP requires only "no blocking findings remaining"
+  (`gen-eval/SKILL.md` → Step 5). The perfect-score variant is what Goodhart's law predicts: it
+  forces either endless repair rounds (observed) or evaluator gaming (the RLVR failure mode).
+- **SIBYL:** story SIBYL-189 — a cockpit _display-positioning_ story — consumed **two formal
+  evaluator rounds at the most expensive profile available (`gpt-5.6-terra @ xhigh`), two full-suite
+  runs (~13 minutes each), six PTY journey scenarios, an actual-checkout dogfood, and a verification
+  ledger**. Of its 28 commits, 8 are feature commits; test code (+2,461 lines) is **1.56×** its
+  feature code (+1,581). Repo-wide, ~22% of the last 100 commits are feature commits, and the
+  verification corpus (29 layer-gate evidence docs, 21 e2e result docs, 37 retrospectives, 114
+  execution records) grows monotonically — nothing ever retires a verification asset.
+- **Both repos sit on v2.5.0**, so neither consumes the v2.7.0 typed-gate/convergence improvements —
+  SIBYL authored them — nor v3.0.0's −37.7% front-tier token footprint.
+
+Four structural defects explain the numbers:
+
+1. **Uniform depth.** Every story gets the maximal gauntlet regardless of blast radius. The only
+   knobs today are Light mode and `policy.md`'s tiers/target/timing — nothing prices _depth_ per
+   story.
+2. **Missing failure taxonomy.** The dogfood report carries severity and category
+   (`executor/references/dogfood-validation.md:160-199`) but not _failure class_ — so an environment
+   failure, a harness flake, and a product defect all route into the same story-filing → gen-eval →
+   recovery-ladder path, the most expensive repair machinery AEP owns. The recovery ladder's "When to
+   Skip the Ladder" (`gen-eval/references/recovery-ladder.md:59-67`) already names "missing external
+   dependency" — but as prose the agent must recall mid-FAIL, which is exactly the class of invariant
+   [deterministic-orchestration.md](deterministic-orchestration.md) showed always drifts.
+3. **The verification ratchet.** The lessons loop is one-directional: failures add verification
+   (thresholds, scripts, evidence docs) and nothing prunes it. `/aep-build` Phase 8 replays **all**
+   prior-layer journeys on **every story** (`build/SKILL.md:237`), making total journey executions
+   O(layers × stories).
+4. **Verification is unpriced.** `execution-record.yaml` records `cost_usd` and per-round gen-eval
+   scores (`wrap/references/convergence.md:70-88`) but nothing separates verification spend from
+   build spend, and no consumer of the record adjusts anything based on it. Topology templates carry
+   token budgets per agent role, but no feedback loop connects actual verification spend to future
+   depth decisions.
+
+---
+
+## The placement principle (cost × tamper-evidence)
+
+Classify every validator on two axes: **cost per run** and **gameability** (can the generator — or a
+reward-hacking future model — satisfy the check without satisfying the intent?). The placement rule:
+
+> **Cheap and tamper-evident validators run in the inner loop, always. Expensive or gameable
+> validators run at the outermost boundary that still catches their failure class, gated by risk.**
+
+| DevOps position                  | Validators                                                                                              | Properties                                            | Frequency                 |
+| -------------------------------- | ------------------------------------------------------------------------------------------------------- | ----------------------------------------------------- | ------------------------- |
+| **Inner loop** (per task/commit) | Typed gates: lint, typecheck, focused Tier-1, schema validation, scope gates, **environment preflight** | Deterministic, named refusals, cannot be rationalized | Every commit              |
+| **Merge boundary** (per story)   | **One** independent evaluator round (diff vs. acceptance contract) + CI + Tier-3 drivers                | Expensive, partially gameable → risk-tiered rounds    | Once per story by default |
+| **Deploy boundary** (per layer)  | Tier-2 journey dogfood on the real target, **full regression replay**, coverage matrices, gate evidence | Expensive but tamper-evident (real execution)         | Once per layer            |
+| **Operate** (post-deploy)        | Telemetry / production outcomes → `/aep-watch` → `/aep-reflect`                                         | The least gameable evidence that exists               | Continuous                |
+| **Human gate**                   | Residual-risk acceptance at layer advance; taxonomy escalations                                         | Most expensive                                        | Per layer + exceptions    |
+
+Two consequences worth naming:
+
+- **Scaling verification means adding typed gates and real-environment evidence, not judge rounds.**
+  An LLM-judge round is the only validator class that gets _simultaneously_ more expensive and more
+  gameable as models improve. Long-horizon models make each round more thorough — which is precisely
+  why rounds must be fewer and more decisive, not more numerous.
+- **A verifier must not share incentives with the generator.** AEP already separates
+  generator/evaluator (`gen-eval/SKILL.md`) and makes `/aep-wrap` execute-never-author journeys. This
+  proposal extends the same separation to _evidence_: a gate flip requires at least one evidence
+  class the generator cannot modify (§ Design 5).
+
+---
+
+## The design
+
+### 1. Failure taxonomy — typed, evaluated before any repair spend
+
+Every FAIL from any tier acquires a **`failure_class`**:
+
+```
+failure_class: product-defect | environment | harness-flake | scope
+```
+
+- **`product-defect`** — the built thing is wrong. Routes to the existing path: finding → story /
+  fix commit → gen-eval.
+- **`environment`** — a precondition outside the worktree is unmet (secrets, credentials, wrong
+  account, target unreachable, quota exhausted). Routes to an **ops checklist surfaced to the
+  human/orchestrator. Never files a code story; never enters the recovery ladder; never spends an
+  evaluation round.** The gate stays refused with a named tag until the environment is repaired,
+  then re-runs.
+- **`harness-flake`** — the test machinery itself misbehaved (race, port collision, known-red
+  baseline). Routes to quarantine + a harness story; the product gate re-runs after quarantine.
+- **`scope`** — the acceptance criterion itself is wrong or the story is mis-sliced. Routes to
+  `/aep-reflect` re-slicing, not to repair rounds.
+
+Two mechanical carriers make the taxonomy typed rather than prose:
+
+- **The unified dogfood report** (`executor/references/dogfood-validation.md` → Unified report
+  format) gains a required `**Failure-Class:**` line per finding; the `dogfood_report` adapter and
+  the `/aep-reflect` Step-2 classifier route on it.
+- **The environment preflight gate**: before any Tier-2/Tier-3 execution (build Phase 6 Step B, wrap
+  layer gate), a preflight probe checks the target's preconditions — required secrets present, auth
+  identity matches the expected account, target reachable, fixtures seedable — and **refuses with
+  named tags** (`REFUSING [dogfood-secret-absent:<NAME>]`, `REFUSING [auth-identity-mismatch:<got≠want>]`)
+  _before_ any journey spend. A refused preflight is `environment` by construction: zero scenarios
+  run, zero findings generated, zero rounds spent. The generated e2e skill's `policy.md` names the
+  preflight probes next to the target it already owns.
+
+The recovery ladder keeps its rungs, but the taxonomy check is promoted from a prose "When to Skip"
+bullet to a **mandatory step at every FAIL, before choosing a rung**: only `product-defect` climbs
+the ladder.
+
+### 2. Risk-tiered verification depth
+
+Each story gets a **`verification_tier`** — **derived at dispatch time from observable facts, not
+hand-authored** (no new required schema field on stories; the tier is computed into the
+machine-assembled brief and recorded in the execution record):
+
+Inputs (all world-derivable at dispatch): number of architecture modules touched
+(`files_affected` overlap), whether an API contract / schema / migration is in scope, whether the
+diff touches security-sensitive paths (auth, payments, data deletion, secrets handling), novelty
+(new module vs. modification of a covered one), and layer kind (walking skeleton vs. enrichment).
+
+| Tier                   | Evaluator rounds (cap)             | Evaluator effort  | Dogfood scope (Phase 6B)           | Full-suite runs               |
+| ---------------------- | ---------------------------------- | ----------------- | ---------------------------------- | ----------------------------- |
+| **light**              | 0 (generator self-review, lenient) | —                 | render smoke / none                | focused only                  |
+| **standard** (default) | **2**, taxonomy check each FAIL    | session default   | affected-surface journey scenarios | focused; full once at land    |
+| **deep**               | up to 5 + full recovery ladder     | highest available | full journey + prior-layer replay  | full pre-eval **and** at land |
+
+- **Hard floor:** stories touching auth, payments, irreversible data operations, or migrations are
+  always `deep`, whatever the derivation says. The human can override any story's tier; overrides are
+  recorded.
+- **Threshold semantics (all tiers):** PASS means **zero blocking findings** against the
+  hard-failure thresholds (`gen-eval/references/scoring-framework.md:107`). A perfect aggregate
+  score is **never** a gate condition — perfect-score gates train evaluator-gaming and block
+  convergence (looplia's 5.00/5.00 rule is the counterexample).
+- The existing round protocol (`gen-eval/references/eval-protocol.md:116`, `max_rounds` default 5)
+  becomes tier-derived; `/aep-build` Phase 5's "max 5" (`build/SKILL.md:126`) reads the tier from
+  the brief.
+
+### 3. Verification accounting — priced, recorded, calibrated
+
+`execution-record.yaml` (`wrap/references/convergence.md:70-88`) gains a `verification:` block,
+gathered best-effort like every other field:
+
+```yaml
+verification:
+  tier: light | standard | deep # as dispatched (+ `override: human` when overridden)
+  eval_rounds: <n>
+  findings_by_round: [<n>, ...] # blocking+important findings per round
+  suite_runs: <n>
+  suite_seconds: <n> | null
+  journey_scenarios_run: <n>
+  preflight_refusals: [] # named tags, if any
+  cost_usd: <n> | null # verification share when separable; else null
+  escaped_defects: [] # filled retroactively by /aep-reflect (see below)
+```
+
+Consumers close the loop:
+
+- **Escape-rate ingestion:** when `/aep-reflect` classifies a post-merge bug, it traces the bug to
+  the story that introduced it and appends to that story's `escaped_defects`. Escape rate (defects
+  that escaped ÷ verification rounds spent) is the calibration signal.
+- **Bidirectional calibration:** layer distillation (already proposal-only,
+  `wrap/references/convergence.md` §2) may propose tier-derivation adjustments **in both
+  directions** — tighten where defects escape, and **loosen or retire** where `findings_by_round`
+  shows round ≥2 catching nothing across a layer. Verification assets get a lifecycle: distillation
+  may propose merging or retiring journeys that have replayed green for N layers with no coverage
+  loss. Proposals only; a human applies them. This is what breaks the ratchet.
+- **The layer budget box:** each layer gate's evidence doc records expected vs. actual verification
+  spend (rounds, suite time, scenarios, `cost_usd` where known). When actuals overrun the box,
+  `/aep-wrap` surfaces a **scope-vs-verification tradeoff to the human** at the layer-advance gate —
+  the loop asks, it does not silently grind. (looplia's tick-444 halt is the degenerate form of this
+  question, asked 10 rounds too late.)
+
+### 4. Regression replay moves from story to layer granularity
+
+- **Per story** (`/aep-build` Phase 8, `build/SKILL.md:237`): replay only **impacted** journeys —
+  those whose `covers:` criteria or module mapping intersects the story's `files_affected`. The
+  journey front-matter (`layer:`, `covers:`) already makes impact selection expressible.
+- **Per layer** (`/aep-wrap` layer gate, `wrap/references/layer-advance.md`): the **full**
+  prior-layer replay stays here, once per layer — this is where cumulative regression belongs, and
+  it keeps the guarantee `/aep-dispatch` relies on (a layer cannot advance past a broken past).
+- Total journey executions drop from O(layers × stories) to O(stories + layers).
+
+### 5. Tamper-evident evidence classes on every gate
+
+A layer gate may flip to `passed` only when its evidence includes **at least one class the
+generator cannot modify**:
+
+1. a CI run bound to the merged SHA;
+2. journey execution performed by `/aep-wrap` (executes-never-authors — existing canon);
+3. **read-only golden fixtures with a ledger-equality oracle** — fixture trees the generator's
+   workspace cannot write, verified by before/after equality of durable state (SIBYL's
+   fixture-repo + SHA-256 ledger comparison is the proven downstream shape; screenshots stay
+   diagnostic, never a pass condition);
+4. production telemetry ingested by `/aep-watch`.
+
+Additionally:
+
+- **Evaluator prompts are machine-assembled** (extending deterministic-orchestration's
+  machine-assembled brief to evaluation): the orchestrating layer — not the generator — assembles
+  the evaluator's context (criteria file, contract file, diff range), so the generator cannot curate
+  what its judge sees.
+- **`policy.md` gains a `live_policy` decision** for cost-bearing dogfoods (live model calls, quota-
+  or fee-metered targets): `every_gate | milestone_gates | none`, with the milestone list named in
+  the policy. Non-milestone gates use zero-cost render smokes / scripted tiers. This upstreams
+  SIBYL's proven `live_policy: milestone_gates_only` pattern. The existing SKIP-not-FAIL degrade
+  semantics stay; the taxonomy separates SKIP (tool absent), REFUSED (environment), and FAIL
+  (product) so none masquerades as another.
+
+---
+
+## What upstream changes now (v3.1.0) vs future
+
+**Now — one teaching reference plus prose edits across the verification-touching skills; no runtime,
+no new required schema fields:**
+
+1. **NEW `skills/patterns/gen-eval/references/verification-economics.md`** — the canonical reference
+   carrying the placement matrix, the failure taxonomy + routing table, the tier presets +
+   derivation inputs, the `verification:` accounting schema, the evidence-class catalog, and the
+   worked examples. It lives under gen-eval because gen-eval already owns evaluation canon and is
+   read by `/aep-build`, `/aep-validate`, and `/aep-launch`; build, wrap, dispatch, reflect, and the
+   e2e scaffold cross-reference it **by name**.
+2. **`skills/patterns/executor/references/dogfood-validation.md`** — Unified report format
+   (`:160-199`): add the required `**Failure-Class:**` line and the four-way routing table
+   (`environment` → ops checklist, never story-filing; `harness-flake` → quarantine; `scope` →
+   re-slice; `product-defect` → existing adapter path).
+3. **`skills/project-setup/e2e-skill-scaffolding/`** — `templates/policy.md.tmpl` + SKILL.md Phase 2
+   confirmation questions gain the `live_policy` decision and the preflight-probe list;
+   `references/layer-gate-loop.md` and `references/three-tier-model.md` add the environment
+   preflight gate (named refusals before any Tier-2/3 spend), the evidence-class requirement on
+   `passed`, and the replay-placement note (impacted per story, full per layer).
+4. **`skills/agentic-development-workflow/build/SKILL.md`** — Phase 5 (`:126-145`): round cap and
+   evaluator effort read from the brief's `verification_tier`; taxonomy check at every FAIL before
+   any ladder rung. Phase 6 Step B (`:194-215`): run the preflight gate before executing; a refusal
+   is `environment`, not a dogfood FAIL. Phase 8 (`:237`): impacted-only journey replay.
+5. **`skills/patterns/gen-eval/references/`** — `eval-protocol.md` (`:116`): `max_rounds` becomes
+   tier-derived. `recovery-ladder.md` (`:59-67`): "When to Skip the Ladder" reframed as the typed
+   taxonomy step run at every FAIL. `scoring-framework.md`: state the zero-blocking-findings
+   threshold semantics and name the perfect-score gate as an anti-pattern.
+6. **`skills/agentic-development-workflow/wrap/references/`** — `convergence.md` (`:70-88`): the
+   `verification:` block in `execution-record.yaml`. `layer-advance.md`: full replay owned here; the
+   budget box; the evidence-class check before flipping `passed`.
+7. **`skills/product-context/dispatch/SKILL.md`** — tier derivation at brief assembly (`:237`,
+   machine-assembled; the observable inputs listed above), recorded in the brief and the dispatch
+   note.
+8. **`skills/product-context/reflect/SKILL.md`** (+ `watch` → `references/telemetry-ingestion.md`) —
+   escape-rate ingestion (trace post-merge bugs to origin stories' `escaped_defects`); distillation
+   may propose tier-derivation and journey-retirement changes, proposal-only.
+9. **`docs/glossary.md`** — new entries: **Verification Tier**, **Failure Class (Failure
+   Taxonomy)**, **Environment Preflight Gate**, **Verification Accounting**, **Escape Rate**,
+   **Tamper-Evident Evidence**, **Verification Ratchet** (anti-pattern), **Perfect-Score Gate**
+   (anti-pattern).
+10. `CHANGELOG.md` `[3.1.0]`; `.claude-plugin/marketplace.json` + `package.json` → `3.1.0`.
+    Product-context skills' edits (dispatch, reflect, watch) go through `_shared/` sources +
+    `build-skills.sh` per the generated-dirs rule.
+
+**Future — explicit non-goals, recorded as horizon:**
+
+- A **held-out / adversarial case vault** (hidden tests the generator never sees, rotated per
+  layer). Needs downstream runtime support for access separation; sliced only after the taxonomy and
+  tiers prove out.
+- Any AEP-shipped verifier runtime, verifier-model training loop, or cost-optimal scheduler. AEP
+  stays prose; the probes and gates belong to the project.
+- Rewriting `/aep-validate`'s protocol checker (its known prose drift is tracked separately in the
+  [v2.5→v3 compatibility audit](../audits/2026-07-15-looplia-v2.5.0-to-v3.0.0-compatibility.md)).
+
+---
+
+## Forcing functions
+
+| Skill           | New responsibility                                                                                              |
+| --------------- | --------------------------------------------------------------------------------------------------------------- |
+| `/aep-gen-eval` | Owns the verification-economics reference; tier-derived round caps; zero-blocking threshold semantics           |
+| `/aep-build`    | Preflight before dogfood; taxonomy check before any ladder rung; impacted-only replay; tier read from the brief |
+| `/aep-wrap`     | Full replay + budget box + evidence-class check at the layer gate; gathers the `verification:` block            |
+| `/aep-dispatch` | Derives `verification_tier` from observable facts into the machine-assembled brief                              |
+| `/aep-reflect`  | Routes on `failure_class`; ingests escape rate; proposes bidirectional calibration                              |
+| e2e scaffold    | `live_policy` + preflight probes in `policy.md`; evidence classes and replay placement in the gate loop         |
+
+## Migration
+
+All changes are prose-additive and fail open: a story with no derived tier behaves as `deep`
+(today's behavior); a report without `Failure-Class:` classifies as `product-defect` (today's
+routing); an execution record without `verification:` stays valid (`story_id` remains the only
+required field); a gate with no named evidence class records a warning, not a refusal, for one
+release.
+
+| Phase                       | Action                                                                                   | Breaking? |
+| --------------------------- | ---------------------------------------------------------------------------------------- | --------- |
+| **P0 — this decision doc**  | Record the evidence, the placement principle, the five design elements                   | No        |
+| **P1 — canon reference**    | Ship `gen-eval/references/verification-economics.md` + glossary entries                  | No        |
+| **P2 — taxonomy carriers**  | Dogfood report `Failure-Class:` + preflight gate (executor, e2e scaffold, build Phase 6) | No        |
+| **P3 — tiers + accounting** | Tier derivation (dispatch), tier-derived rounds (build/gen-eval), `verification:` (wrap) | No        |
+| **P4 — calibration + bump** | Reflect/distillation calibration, replay move, budget box; v3.1.0                        | No        |
+
+**Exact change sites:** the numbered list under "What upstream changes now" is the implementation
+PRs' review contract.
+
+**Propagation discipline:** this proposal introduces net-new taxonomy — _failure class_,
+_verification tier_, _environment preflight gate_, _tamper-evident evidence_, _escape rate_,
+_verification ratchet_, _perfect-score gate_ — and two new enums (`failure_class` values;
+`live_policy` values). Every skill that names one must say it identically; the glossary defines
+each; audit with `grep -rn "failure_class\|verification_tier\|live_policy\|preflight" skills/ docs/`
+after implementation. `live_policy` joins `applicable_tiers`/`dogfood_target`/`journey_timing` in
+**every** policy listing (e2e templates, three-tier-model, layer-gate-loop, build Phase 6, wrap) —
+half-applied enums are this repo's #1 historical bug class. Dispatch/reflect/watch edits are made in
+`skills/product-context/_shared/` and regenerated via `scripts/build-skills.sh`; `skills:check` must
+come back clean. Downstream consumers go live only after the v3.1.0 tag is cut and each consumer
+re-pins via the skills CLI.
+
+---
+
+## Worked examples
+
+**looplia L31, replayed under this design.** The post-deploy gate's preflight probes run before any
+scenario: `REFUSING [dogfood-secret-absent:LOOPLIA_E2E_FIXTURE_SECRET]`,
+`REFUSING [auth-identity-mismatch:account …d422b ≠ …88e6]`. Classification is `environment` by
+construction — an ops checklist (set the two secrets, re-auth Wrangler to the prod account) surfaces
+to the human; the gate stays `scripted_passed` with named blockers. **Zero journey scenarios spent,
+zero code stories filed, zero evaluation rounds, no autopilot halt.** The actual history — two
+recovery stories, ten exhausted evaluation rounds, a paused loop, and a layer stuck at 68/75
+coverage on criteria the recovery itself created — is the cost of routing an environment failure
+through product-defect machinery.
+
+**SIBYL-189, replayed under `standard` tier.** Round 1 caught two real findings (armed-quit
+priority, a matrix misclassification the new oracle exposed); the fixes landed; round 2 passed with
+zero blocking findings — exactly the two rounds `standard` allows, so the catch quality is
+unchanged. What the tier removes: the second full-suite run (~13 minutes; the land verify already
+runs the suite on merged main) and the top-shelf evaluator profile for a display-positioning story —
+the findings were caught by the focused matrix oracle and an ordinary evaluation round, not by
+`xhigh` reasoning. The PTY journey and ledger-equality dogfood stay: they are the tamper-evident
+half of the gate.
+
+**SIBYL's `live_policy: milestone_gates_only`** (live-model dogfoods only at the L2/L4/L6 milestone
+gates; zero-quota render smokes elsewhere) is the proven downstream shape of the `live_policy`
+decision this proposal adds to `policy.md` — evidence that pricing the expensive half of dogfood
+per-gate, instead of running it uniformly, holds up across 20+ layers of real use.
+
+---
+
+## Anti-patterns this prevents
+
+- **Perfect-score gates.** "Exactly 5.00/5.00 with zero findings" trains the generator to satisfy
+  the evaluator, not the product, and turns ordinary convergence into round exhaustion. PASS is zero
+  blocking findings.
+- **Environment failures fed to code-repair machinery.** A missing secret is not a 2.79/5.00 code
+  problem; no evaluation round may be spent before the taxonomy step runs.
+- **Per-story full-regression replay.** O(layers × stories) journey executions; full replay belongs
+  to the layer gate.
+- **Uninstrumented verification.** 444 ticks with `total_cost_usd: 0` recorded means the loop cannot
+  know it is over-verifying; unpriced spend grows until it displaces the product.
+- **The verification ratchet.** A lessons loop that only ever adds verification converges on a
+  process that verifies instead of shipping; calibration must be able to loosen and retire.
+- **Scaling verification with judge rounds.** More LLM-judge rounds is the only scaling direction
+  that gets more expensive and more gameable at once; add typed gates and real-environment evidence
+  instead.
+- **Self-curated evidence.** A generator that assembles its own evaluator's context, or can write
+  the fixtures it is graded against, is player, referee, and witness at once.
+
+---
+
+## References
+
+- `SIBYL/openspec/changes/archive/2026-07-15-SIBYL-189/` (`tasks.md`, `execution/eval.yaml`) and
+  `SIBYL/skills/e2e-test/results/2026-07-16-s189-current-position.md` — the S189 verification
+  lifecycle and the ledger-equality oracle.
+- `looplia/.dev-workflow/autopilot-status.md`, `looplia/.dev-workflow/dogfood-l31-006.md` and
+  `…/dogfood-l31-006/02-auth-recovery-audit.md`, `looplia/lessons-learned/l31-014-…md` — the L31
+  halt, the environment misrouting, and the perfect-score ratchet.
+- `SIBYL/product-context.yaml` → `topology.routing.dogfood.live_policy: milestone_gates_only` — the
+  downstream prior art for `live_policy`.
+- [deterministic-orchestration.md](deterministic-orchestration.md) — the mechanical/judgment split
+  and typed-gate pattern this document extends to verification routing, depth, and accounting.
+- [build-convergence-pipeline.md](build-convergence-pipeline.md) — the execution-record gather this
+  document's `verification:` block rides on.
+- [2026-07-15 looplia compatibility audit](../audits/2026-07-15-looplia-v2.5.0-to-v3.0.0-compatibility.md)
+  — the v2.5→v3 baseline both consumers migrate across before any of this lands downstream.
+- Affected skills: `/aep-gen-eval`, `/aep-build`, `/aep-wrap`, `/aep-dispatch`, `/aep-reflect`,
+  `/aep-watch`, `/aep-e2e-skill-scaffolding`, `/aep-executor`.

--- a/docs/decisions/verification-economics.md
+++ b/docs/decisions/verification-economics.md
@@ -252,6 +252,35 @@ between planning and merge:
 | **standard** (default) | **2** — one decisive fix-and-reverify cycle | session default   | impacted-surface journey + canary | focused; full once at land    |
 | **deep**               | up to 5 + full recovery ladder              | highest available | full journey + prior-layer replay | full pre-eval **and** at land |
 
+**The derivation outputs a recipe, not just a depth.** The scoring framework already carries the
+other half of verification cost: _which dimensions_ the evaluator scores
+(`scoring-framework.md` → Dimension Presets — UI-heavy, API-only, Security-sensitive, Data
+pipeline, Mixed) and _which dimension-level hard floors_ apply (e.g. the Security-sensitive
+preset's `Security < 4` fail). Today preset selection is an interactive judgment at launch — made
+from the **same signals the tier derives from**, but independently, so a `sensitive_paths` story
+can derive `deep` while its evaluator runs the Mixed preset without the Security hard floor. The
+derivation therefore emits one **verification recipe** — tier + dimension preset + dimension hard
+floors — from one set of inputs:
+
+- `sensitive_paths` match → **Security-sensitive preset**, and its `Security ≥ 4` /
+  `Data Privacy ≥ 4` floors become part of the tier hard floor — they survive any customization;
+- `ui`-kind module / `calibration_type` in {visual-design, ux-flow} / `object_model_refs` →
+  **UI-heavy preset**, and only these stories pay for **Visual Design** — the most expensive
+  dimension (screenshot capture + multimodal evaluation). Dimension cost follows the shipped
+  surface, never habit;
+- data/migration paths → **Data pipeline preset** (Data Integrity floor);
+- story-map / product-context artifacts (walking-skeleton design) → the **Product & Design
+  dimensions**;
+- otherwise → **Mixed** with default thresholds.
+
+Customization keeps the ratchet direction: launch or the human may **add** dimensions or raise
+thresholds, never drop a derived preset's hard-floor dimensions — the same
+tamper-resistance rule as the tier binding. Per tier: `light` scores no dimensions (self-review);
+`standard` runs the derived preset; `deep` runs it with no de-weighted dimensions. The framework's
+existing advice — _"weight dimensions toward areas where the model falls short"_ — becomes
+data-driven through the accounting below: findings and escapes are attributable per dimension, so
+calibration can propose re-weighting from evidence instead of intuition.
+
 **How the tier travels the trigger path.** Gen-eval is not self-triggering — it is configured down
 the chain autopilot → dispatch → launch → build, and the tier must ride that exact chain or it
 governs nothing:
@@ -312,6 +341,7 @@ verification:
   scope_drift: true | false # binding diff left the declared files_affected
   eval_rounds: <n> | null # from signals/eval-response-*.md count
   findings_by_round: [<n>, ...] | null # blocking+important per round; needs per-round persistence
+  finding_dimensions: [<dimension>, ...] | null # dimensions breached across rounds; feeds dimension re-weighting
   journey_scenarios_run: <n> | null # from the dogfood report
   preflight_refusals: [] # named tags, if any; [] when preflight passed
   cost_usd: <n> | null # verification share when separable
@@ -436,16 +466,22 @@ no new required schema fields:**
    persistence. `recovery-ladder.md` (`:3`, `:25-31`, `:59-67`): the second `max_rounds` copy; rungs
    re-keyed relative to the tier cap; "When to Skip the Ladder" reframed as the typed taxonomy step
    with the class mapping. `scoring-framework.md`: zero-blocking threshold semantics; perfect-score
-   gates named as an anti-pattern.
+   gates named as an anti-pattern; the Customization Guide's preset-selection step becomes
+   **recipe-derived** (the derivation-inputs → preset + hard-floor mapping from § Design 2), with
+   the ratchet rule — customization adds dimensions or raises thresholds, never drops a derived
+   hard floor.
 6. **`skills/agentic-development-workflow/launch/`** — `SKILL.md` "Optional: Evaluator (Full
-   Mode)" (`:199-205`): evaluator existence, criteria, and effort become **tier-derived from the
-   dispatch brief** (light → no criteria file; standard → preset criteria; deep → tailored criteria
-   - top effort) — this replaces the workflow-modes full/light heuristics as launch's decision
-     rule and gives autonomous launches a deterministic criteria policy.
-     `references/evaluator.md` (`:73-74`): the third `max_rounds` copy goes tier-derived; the
-     criteria-brainstorm step notes the autonomous fallback per tier.
-     `references/signals-spec.md`: `status.json` gains `verification_tier`, `tier_escalated`, and
-     latest-FAIL `failure_class` — the fields autopilot's tier-aware monitoring reads.
+   Mode)" (`:199-205`): evaluator existence, criteria, and effort become **recipe-derived from the
+   dispatch brief** (light → no criteria file; standard → the derived dimension preset; deep →
+   the derived preset with nothing de-weighted, at top effort) — this replaces the workflow-modes
+   full/light heuristics as launch's decision rule and gives autonomous launches a deterministic
+   criteria policy.
+   `references/evaluator.md` (`:73-74`): the third `max_rounds` copy goes tier-derived; the
+   criteria-brainstorm step assembles `.dev-workflow/evaluator-criteria.md` from the derived
+   recipe, and interactive customization only ratchets up (add dimensions / raise thresholds,
+   never drop derived hard floors).
+   `references/signals-spec.md`: `status.json` gains `verification_tier`, `tier_escalated`, and
+   latest-FAIL `failure_class` — the fields autopilot's tier-aware monitoring reads.
 7. **`skills/agentic-development-workflow/wrap/references/`** — `convergence.md` (`:70-88`): the
    `verification:` block. `layer-advance.md`: full replay + mid-layer checkpoint policy + budget box
    - evidence-class check before flipping `passed`.
@@ -471,7 +507,8 @@ no new required schema fields:**
     guard report; `live_policy` governs the guard's live half.
 11. **`skills/agentic-development-workflow/design/references/workflow-modes.md`** — Light mode's
     eval-loop behavior subsumed into `verification_tier: light`.
-12. **`docs/glossary.md`** — new entries: **Verification Tier**, **Failure Class (Failure
+12. **`docs/glossary.md`** — new entries: **Verification Tier**, **Verification Recipe** (tier +
+    dimension preset + dimension hard floors, one derivation), **Failure Class (Failure
     Taxonomy)**, **Classification Authority**, **Environment Preflight Gate**, **Verification
     Accounting**, **Escape Rate**, **Tamper-Evident Evidence**, **Verification Ratchet**
     (anti-pattern), **Perfect-Score Gate** (anti-pattern) — the Verification Tier entry


### PR DESCRIPTION
## Summary

Decision doc for the v3.1.0 direction, per the decision-doc-first convention (no schema/skill edits in this PR): how AEP prices verification and where each validator class belongs in the DevOps loop.

**The five design elements:**
1. **Typed failure taxonomy** (`product-defect | environment | harness-flake | scope`) evaluated before any repair spend, carried by the unified dogfood report and an environment-preflight typed gate with named refusals
2. **Risk-tiered verification depth** (`light | standard | deep`) derived at dispatch from observable facts; zero-blocking-findings threshold semantics (perfect-score gates named as an anti-pattern)
3. **Verification accounting** — a `verification:` block in `execution-record.yaml` + escape-rate ingestion + bidirectional calibration (the ratchet becomes prunable)
4. **Regression replay moves story → layer** (impacted-only per story; full replay at the layer gate) — O(layers × stories) → O(stories + layers)
5. **Tamper-evident evidence classes** required on every layer gate flip; evaluator prompts machine-assembled; `live_policy` upstreamed from SIBYL

## Evidence base

Sourced from the 2026-07-16 cross-repo research: looplia L31 (16:84 feature:process commit ratio; an environment failure routed through 10 evaluation rounds into a full autopilot halt) and SIBYL S189 (2× Terra xhigh rounds + 2 full-suite runs + PTY dogfood for a display-positioning story; test code 1.56× feature code).

## Review contract

The numbered list under "What upstream changes now (v3.1.0)" is the implementation PRs' review contract. Migration is prose-additive and fail-open (no tier → deep; no Failure-Class → product-defect; no verification block → valid record).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wa9sWJXDc6JrLtVKpSsdJn