### PR TITLE
fix(e2e): secret_scan example uses supported gitleaks git --staged (v3.2.1)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
     "email": "mho@looplia.run"
   },
   "metadata": {
-    "version": "3.2.0",
+    "version": "3.2.1",
     "description": "Skills for product planning, project scaffolding, and agentic development workflows."
   },
   "plugins": [

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,24 @@ bug fixes → **patch**; removing or breaking a skill contract → **major**.
 > `/envision`, `/dispatch`, `/reflect`, …), which records product-state history
 > for that project. See [`docs/glossary.md`](docs/glossary.md).
 
+## [3.2.1] - 2026-07-18
+
+Patch: the `secret_scan` example in the scaffolded `policy.md` named
+`gitleaks protect --staged`. In current gitleaks (8.30.x) `protect` is a
+hidden/deprecated alias absent from the documented command set — the supported
+staged-scan form is `gitleaks git --staged`. This is a doc-string example only
+(the scaffolder renders `{{SECRET_SCAN_CMD}}` from the project's actual tooling,
+and no shipped script executes the comment), but it seeded the deprecated form
+into consumers (surfaced by the MITS v3.2.0 Phase-3 review). Re-pin to `@v3.2.1`
+before the remaining consumer migrations so they inherit the durable form.
+
+### Fixed
+
+- **`policy.md.tmpl` `secret_scan` example** — `gitleaks protect --staged` →
+  `gitleaks git --staged --redact --no-banner`, matching the form SIBYL and
+  looplia already settled on
+  (`skills/project-setup/e2e-skill-scaffolding/templates/policy.md.tmpl`).
+
 ## [3.2.0] - 2026-07-16
 
 The economics half of

--- a/skills/project-setup/e2e-skill-scaffolding/templates/policy.md.tmpl
+++ b/skills/project-setup/e2e-skill-scaffolding/templates/policy.md.tmpl
@@ -98,7 +98,7 @@ The mechanically detectable half of security never routes to an LLM judge — it
 every commit, and findings are `product-defect` by construction:
 
 ```
-secret_scan : {{SECRET_SCAN_CMD}}   # e.g. gitleaks protect --staged
+secret_scan : {{SECRET_SCAN_CMD}}   # e.g. gitleaks git --staged --redact --no-banner
 sast        : {{SAST_CMD}}          # e.g. semgrep --config auto; "none" if deliberately not adopted
 ```
 


### PR DESCRIPTION
Patch **v3.2.1**. The scaffolded `policy.md`'s `secret_scan` example named `gitleaks protect --staged`. In current gitleaks (8.30.x) `protect` is a hidden/deprecated alias absent from the documented command set — the supported staged-scan form is `gitleaks git --staged`.

Surfaced by the **MITS v3.2.0 Phase-3 review** (memorysaver/MITS#74): the finding was real but non-blocking, and traced back to *this* template example, which MITS (and looplia #292) copied verbatim. Fixing upstream so the 3 remaining consumer migrations inherit the durable form.

### Scope
- `policy.md.tmpl`: `gitleaks protect --staged` → `gitleaks git --staged --redact --no-banner` (the form SIBYL + looplia already settled on).
- Doc-string example only — the scaffolder renders `{{SECRET_SCAN_CMD}}` from the project's actual tooling, and no shipped script executes the comment. No behavior change.
- CHANGELOG `[3.2.1]` entry + `marketplace.json` `3.2.0 → 3.2.1`.

Patch per the repo's SemVer rule (CHANGELOG: "recipe and bug fixes → patch"). Only occurrence in the tree; `grep -rn "gitleaks protect"` now matches only the CHANGELOG note documenting the fix.

### After merge
Tag `v3.2.1` + GitHub Release, then re-pin remaining consumers to `@v3.2.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wa9sWJXDc6JrLtVKpSsdJn